### PR TITLE
Upgraded hawkular inventory API version to 0.17.1.Final

### DIFF
--- a/mgmtsystem/hawkular.py
+++ b/mgmtsystem/hawkular.py
@@ -26,33 +26,35 @@ hawkular:
     password: secret
 """
 
-Feed = namedtuple('Feed', ['id', 'name', 'path'])
+Feed = namedtuple('Feed', ['id', 'path'])
 ResourceType = namedtuple('ResourceType', ['id', 'name', 'path'])
 Resource = namedtuple('Resource', ['id', 'name', 'path'])
 ResourceData = namedtuple('ResourceData', ['name', 'path', 'value'])
 Server = namedtuple('Server', ['id', 'name', 'path', 'data'])
 Deployment = namedtuple('Deployment', ['id', 'name', 'path'])
 Datasource = namedtuple('Datasource', ['id', 'name', 'path'])
+OperationType = namedtuple('OperationType', ['id', 'name', 'path'])
 ServerStatus = namedtuple('ServerStatus', ['address', 'version', 'state', 'product', 'host'])
 Event = namedtuple('event', ['id', 'eventType', 'ctime', 'dataSource', 'dataId',
                              'category', 'text'])
 
-PATH_NAME_MAPPING = {
-    '/t;': 'tenant',
-    '/e;': 'environment',
-    '/rt;': 'resource_type',
-    '/mt;': 'metric_type',
-    '/f;': 'feed',
-    '/ot;': 'operation_type',
-    '/mp;': 'metadata_pack',
-    '/r;': 'resource',
-    '/d;': 'data',
-    '/rl;': 'relationship',
+CANONICAL_PATH_NAME_MAPPING = {
+    '/d;': 'data_id',
+    '/e;': 'environment_id',
+    '/f;': 'feed_id',
+    '/m;': 'metric_id',
+    '/mp;': 'metadata_pack_id',
+    '/mt;': 'metric_type_id',
+    '/ot;': 'operation_type_id',
+    '/r;': 'resource_id',
+    '/rl;': 'relationship_id',
+    '/rt;': 'resource_type_id',
+    '/t;': 'tenant_id',
 }
 
 
-class Path(object):
-    """Path class
+class CanonicalPath(object):
+    """CanonicalPath class
 
     Path is class to split canonical path to friendly values.\
     If the path has more than one entry for a resource result will be in list
@@ -72,31 +74,66 @@ class Path(object):
 
     """
     def __init__(self, path):
-        self.paths = {'raw': path}
-        if self.raw:
-            raw_paths = re.split(r'(/\w+;)', self.raw)
-            if len(raw_paths) % 2 == 1:
-                del raw_paths[0]
-            for p_index in range(0, len(raw_paths), 2):
-                if PATH_NAME_MAPPING[raw_paths[p_index]] in self.paths:
-                    if isinstance(self.paths[PATH_NAME_MAPPING[raw_paths[p_index]]], list):
-                        self.paths[PATH_NAME_MAPPING[raw_paths[p_index]]] \
-                            .append(raw_paths[p_index + 1])
-                    else:
-                        v_list = [
-                            self.paths[PATH_NAME_MAPPING[raw_paths[p_index]]],
-                            raw_paths[p_index + 1]
-                        ]
-                        self.paths.update({PATH_NAME_MAPPING[raw_paths[p_index]]: v_list})
+        if path is None or len(path) == 0:
+            raise KeyError("CanonicalPath should not be None or empty!")
+        self._path_ids = []
+        r_paths = re.split(r'(/\w+;)', path)
+        if len(r_paths) % 2 == 1:
+            del r_paths[0]
+        for p_index in range(0, len(r_paths), 2):
+            path_id = CANONICAL_PATH_NAME_MAPPING[r_paths[p_index]]
+            path_value = r_paths[p_index + 1]
+            if path_id in self._path_ids:
+                if isinstance(getattr(self, path_id), list):
+                    ex_list = getattr(self, path_id)
+                    ex_list.append(path_value)
+                    setattr(self, path_id, ex_list)
                 else:
-                    self.paths.update(
-                        {PATH_NAME_MAPPING[raw_paths[p_index]]: raw_paths[p_index + 1]})
+                    v_list = [
+                        getattr(self, path_id),
+                        path_value
+                    ]
+                    setattr(self, path_id, v_list)
+            else:
+                self._path_ids.append(path_id)
+                setattr(self, path_id, path_value)
+
+    def __iter__(self):
+        """This enables you to iterate through like it was a dictionary, just without .iteritems"""
+        for path_id in self._path_ids:
+            yield (path_id, getattr(self, path_id))
 
     def __repr__(self):
-        return self.paths['raw'] if 'raw' in self.paths else None
+        return "<CanonicalPath {}>".format(self.to_string)
 
-    def __getattr__(self, name):
-        return self.paths[name] if name in self.paths else None
+    @property
+    def to_string(self):
+        c_path = ''
+        if 'tenant_id' in self._path_ids:
+            c_path = "/t;{}".format(self.tenant_id)
+        if 'feed_id' in self._path_ids:
+            c_path += "/f;{}".format(self.feed_id)
+        if 'environment_id' in self._path_ids:
+            c_path += "/e;{}".format(self.environment_id)
+        if 'metric_id' in self._path_ids:
+            c_path += "/m;{}".format(self.metric_id)
+        if 'resource_id' in self._path_ids:
+            if isinstance(self.resource_id, list):
+                for _resource_id in self.resource_id:
+                    c_path += "/r;{}".format(_resource_id)
+            else:
+                c_path += "/r;{}".format(self.resource_id)
+        if 'metric_type_id' in self._path_ids:
+            c_path += "/mt;{}".format(self.metric_type_id)
+        if 'resource_type_id' in self._path_ids:
+            c_path += "/rt;{}".format(self.resource_type_id)
+        if 'metadata_pack_id' in self._path_ids:
+            c_path += "/mp;{}".format(self.metadata_pack_id)
+        if 'operation_type_id' in self._path_ids:
+            c_path += "/ot;{}".format(self.operation_type_id)
+        if 'relationship_id' in self._path_ids:
+            c_path += "/rl;{}".format(self.relationship_id)
+        return c_path
 
 
 class Hawkular(MgmtSystemAPIBase):
@@ -127,12 +164,9 @@ class Hawkular(MgmtSystemAPIBase):
         self.hostname = hostname
         self.username = kwargs.get('username', '')
         self.password = kwargs.get('password', '')
+        self.tenant_id = kwargs.get('tenant_id', 'hawkular')
         self.auth = self.username, self.password
         self.inv_api = ContainerClient(hostname, self.auth, protocol, port, "hawkular/inventory")
-        # temporary solution, switching to deprecated API
-        if self._check_inv_version('0.17'):
-            self.inv_api = ContainerClient(hostname, self.auth, protocol, port,
-                                           "hawkular/inventory/deprecated")
         self.alerts_api = ContainerClient(hostname, self.auth, protocol, port, "hawkular/alerts")
 
     def _check_inv_version(self, version):
@@ -210,78 +244,131 @@ class Hawkular(MgmtSystemAPIBase):
     def wait_vm_suspended(self, vm_name, num_sec):
         raise NotImplementedError('wait_vm_suspended not implemented.')
 
-    def list_server_deployment(self, **kwargs):
+    def list_server_deployment(self, feed_id=None):
         """Returns list of server deployments. Possible filters: `feed_id`"""
-        resources = self.list_resource(type_id='Deployment',
-                                       feed_id=kwargs['feed_id'] if 'feed_id' in kwargs else None)
+        resources = self.list_resource(feed_id=feed_id, resource_type_id='Deployment')
         deployments = []
         if resources:
             for resource in resources:
                 deployments.append(Deployment(resource.id, resource.name, resource.path))
         return deployments
 
-    def list_server(self, **kwargs):
+    def list_server(self, feed_id=None):
         """Returns list of middleware servers. Possible filters: `feed_id`"""
-        resources = self.list_resource(type_id='WildFly Server',
-                                       feed_id=kwargs['feed_id'] if 'feed_id' in kwargs else None)
+        resources = self.list_resource(feed_id=feed_id, resource_type_id='WildFly Server')
         servers = []
         if resources:
             for resource in resources:
-                resource_data = self.resource_data(
-                    feed_id=resource.path.feed, resource_id=resource.id)
-                server_data = {'data_name': resource_data.name}
-                server_data.update(resource_data.value)
+                resource_data = self.get_config_data(
+                    feed_id=resource.path.feed_id, resource_id=resource.id)
+                server_data = resource_data.value
                 servers.append(Server(resource.id, resource.name, resource.path, server_data))
         return servers
 
-    def list_resource(self, **kwargs):
+    def list_resource(self, resource_type_id, feed_id=None):
         """Returns list of resources. Possible filters: `feed_id`, `type_id`"""
-        feed_id = kwargs['feed_id'] if 'feed_id' in kwargs else None
         if not feed_id:
             resources = []
-            feeds = self.list_feed()
-            for feed in feeds:
-                resources = \
-                    resources + self._list_resource(type_id=kwargs['type_id'], feed_id=feed.id)
+            for feed in self.list_feed():
+                resources.extend(self._list_resource(feed_id=feed.path.feed_id,
+                                                    resource_type_id=resource_type_id))
             return resources
         else:
-            return self._list_resource(type_id=kwargs['type_id'], feed_id=feed_id)
+            return self._list_resource(feed_id=feed_id, resource_type_id=resource_type_id)
 
-    def _list_resource(self, **kwargs):
-        """Returns list of resources by provided `type_id` and `feed_id`"""
-        if not kwargs or 'feed_id' not in kwargs:
-            raise KeyError('Variable "feed_id" is a mandatory field!')
-        entities = []
-        if kwargs['type_id']:
-            entities_j = self._get_inv_json('feeds/{}/resourceTypes/{}/resources'
-                                        .format(kwargs['feed_id'], kwargs['type_id']))
+    def list_child_resource(self, feed_id, resource_id, recursive=False):
+        """Returns list of resources. Possible filters: `feed_id`, `type_id`"""
+        if not feed_id or not resource_id:
+            raise KeyError("'feed_id' and 'resource_id' are a mandatory field!")
+        resources = []
+        if recursive:
+            entities_j = self._get_inv_json('traversal/f;{}/r;{}/recursive;over=isParentOf;type=r'
+                                          .format(feed_id, resource_id))
         else:
-            entities_j = self._get_inv_json('feeds/{}/resources'.format(kwargs['feed_id']))
+            entities_j = self._get_inv_json('traversal/f;{}/r;{}/type=r'
+                                            .format(feed_id, resource_id))
         if entities_j:
             for entity_j in entities_j:
-                entities.append(Resource(entity_j['id'], entity_j['name'], Path(entity_j['path'])))
+                resources.append(Resource(entity_j['id'], entity_j['name'],
+                                          CanonicalPath(entity_j['path'])))
+        return resources
+
+    def _list_resource(self, feed_id, resource_type_id=None):
+        """Returns list of resources by provided `type_id` and `feed_id`"""
+        if not feed_id:
+            raise KeyError("'feed_id' is a mandatory field!")
+        entities = []
+        if resource_type_id:
+            entities_j = self._get_inv_json('traversal/f;{}/rt;{}/rl;defines/type=r'
+                                        .format(feed_id, resource_type_id))
+        else:
+            entities_j = self._get_inv_json('traversal/f;{}/type=r'.format(feed_id))
+        if entities_j:
+            for entity_j in entities_j:
+                entities.append(Resource(entity_j['id'], entity_j['name'],
+                                         CanonicalPath(entity_j['path'])))
         return entities
 
-    def resource_data(self, **kwargs):
+    def get_config_data(self, feed_id, resource_id):
         """Returns the data/configuration information about resource by provided\
          `feed_id` and `resource_id`."""
-        if not kwargs or 'feed_id' not in kwargs or 'resource_id' not in kwargs:
-            raise KeyError('Variable "feed_id" and "resource_id" are mandatory field!')
-        entity_j = self._get_inv_json('feeds/{}/resources/{}/data'
-                                     .format(kwargs['feed_id'], kwargs['resource_id']))
+        if not feed_id or not resource_id:
+            raise KeyError("'feed_id' and 'resource_id' are mandatory field!")
+        entity_j = self._get_inv_json('entity/f;{}/r;{}/d;configuration'
+                                      .format(feed_id, resource_id))
         if entity_j:
-            return ResourceData(entity_j['name'], Path(entity_j['path']), entity_j['value'])
+            return ResourceData(entity_j['name'], CanonicalPath(entity_j['path']),
+                                entity_j['value'])
         return None
 
-    def edit_resource_data(self, resource_data, **kwargs):
+    def list_feed(self):
+        """Returns list of feeds"""
+        entities = []
+        entities_j = self._get_inv_json('traversal/type=f')
+        if entities_j:
+            for entity_j in entities_j:
+                entities.append(Feed(entity_j['id'], CanonicalPath(entity_j['path'])))
+        return entities
+
+    def list_resource_type(self, feed_id):
+        """Returns list of resource types by provided `feed_id`"""
+        if not feed_id:
+            raise KeyError("'feed_id' is a mandatory field!")
+        entities = []
+        entities_j = self._get_inv_json('traversal/f;{}/type=rt'.format(feed_id))
+        if entities_j:
+            for entity_j in entities_j:
+                entities.append(ResourceType(entity_j['id'], entity_j['name'], entity_j['path']))
+        return entities
+
+    def list_operation_definition(self, feed_id, resource_type_id):
+        if feed_id is None or resource_type_id is None:
+            raise KeyError("'feed_id' and 'resource_type_id' are mandatory fields!")
+        res_j = self._get_inv_json('traversal/f;{}/rt;{}/type=ot'.format(feed_id, resource_type_id))
+        operations = []
+        if res_j:
+            for res in res_j:
+                operations.append(OperationType(res['id'], res['name'], CanonicalPath(res['path'])))
+        return operations
+
+    def list_server_datasource(self, feed_id=None):
+        """Returns list of datasources. Possible filters: `feed_id`"""
+        resources = self.list_resource(feed_id=feed_id, resource_type_id='Datasource')
+        datasources = []
+        if resources:
+            for resource in resources:
+                datasources.append(Datasource(resource.id, resource.name, resource.path))
+        return datasources
+
+    def edit_config_data(self, resource_data, **kwargs):
         """Edits the data.value information for resource by provided\
          `feed_id` and `resource_id`."""
         if not isinstance(resource_data, ResourceData) or not resource_data.value:
             raise KeyError(
                 "'resource_data' should be ResourceData with 'value' attribute")
         if not kwargs or 'feed_id' not in kwargs or 'resource_id' not in kwargs:
-            raise KeyError('Variable "feed_id" and "resource_id" are mandatory field!')
-        r = self._pup_inv_status('feeds/{}/resources/{}/data'
+            raise KeyError("'feed_id' and 'resource_id' are mandatory field!")
+        r = self._put_inv_status('entity/f;{}/r;{}/d;configuration'
                 .format(kwargs['feed_id'], kwargs['resource_id']), {"value": resource_data.value})
         return r
 
@@ -299,52 +386,25 @@ class Hawkular(MgmtSystemAPIBase):
             raise KeyError('Variable "feed_id" id mandatory field!')
 
         resource_id = urlquote(resource.id, safe='')
-
-        r = self._post_inv_status('feeds/{}/resources'.format(kwargs['feed_id']),
+        r = self._post_inv_status('entity/f;{}/resource'.format(kwargs['feed_id']),
                                 data={"name": resource.name, "id": resource.id,
-                                "resourceTypePath": resource_type.path})
+                                "resourceTypePath": "rt;{}"
+                                  .format(resource_type.path.resource_type_id)})
         if r:
-            r = self._post_inv_status('feeds/{}/resources/{}/data'
+            r = self._post_inv_status('entity/f;{}/r;{}/data'
                                     .format(kwargs['feed_id'], resource_id),
                                     data={'role': 'configuration', "value": resource_data.value})
-        if not r:
+        else:
             # if resource or it's data was not created correctly, delete resource
-            self._delete_inv_status('feeds/{}/resources/{}'
-                                .format(kwargs['feed_id'], resource_id))
+            self._delete_inv_status('entity/f;{}/r;{}'.format(kwargs['feed_id'], resource_id))
         return r
 
-    def delete_resource(self, **kwargs):
-        """Removed the resource by provided\
-         `feed_id` and `resource_id`."""
-        if not kwargs or 'feed_id' not in kwargs or 'resource_id' not in kwargs:
-            raise KeyError('Variable "feed_id" and "resource_id" are mandatory field!')
-        r = self._delete_inv_status('feeds/{}/resources/{}'
-                                .format(kwargs['feed_id'], kwargs['resource_id']))
+    def delete_resource(self, feed_id, resource_id):
+        """Removed the resource by provided `feed_id` and `resource_id`."""
+        if not feed_id or not resource_id:
+            raise KeyError("'feed_id' and 'resource_id' are mandatory fields!")
+        r = self._delete_inv_status('entity/f;{}/r;{}'.format(feed_id, resource_id))
         return r
-
-    def list_feed(self):
-        """Returns list of feeds"""
-        entities = []
-        entities_j = self._get_inv_json('feeds')
-        if entities_j:
-            for entity_j in entities_j:
-                entity = Feed(entity_j['id'],
-                              entity_j['name'] if 'name' in entity_j else None,
-                              Path(entity_j['path']))
-                entities.append(entity)
-        return entities
-
-    def list_resource_type(self, **kwargs):
-        """Returns list of resource types by provided `feed_id`"""
-        if not kwargs or 'feed_id' not in kwargs:
-            raise KeyError('Variable "feed_id" is a mandatory field!')
-        entities = []
-        entities_j = self._get_inv_json('feeds/{}/resourceTypes'.format(kwargs['feed_id']))
-        if entities_j:
-            for entity_j in entities_j:
-                entity = ResourceType(entity_j['id'], entity_j['name'], entity_j['path'])
-                entities.append(entity)
-        return entities
 
     def list_event(self, start_time=0, end_time=sys.maxsize):
         """Returns the list of events filtered by provided start time and end time.
@@ -361,30 +421,20 @@ class Hawkular(MgmtSystemAPIBase):
                 entities.append(entity)
         return entities
 
-    def list_server_datasource(self, **kwargs):
-        """Returns list of datasources. Possible filters: `feed_id`"""
-        resources = self.list_resource(type_id='Datasource',
-                                       feed_id=kwargs['feed_id'] if 'feed_id' in kwargs else None)
-        datasources = []
-        if resources:
-            for resource in resources:
-                datasources.append(Datasource(resource.id, resource.name, resource.path))
-        return datasources
-
     def _get_inv_json(self, path):
-        return self.inv_api.get_json(path, headers={"Hawkular-Tenant": "hawkular"})
+        return self.inv_api.get_json(path, headers={"Hawkular-Tenant": self.tenant_id})
 
     def _post_inv_status(self, path, data):
         return self.inv_api.post_status(path, data,
-                                        headers={"Hawkular-Tenant": "hawkular",
+                                        headers={"Hawkular-Tenant": self.tenant_id,
                                                 "Content-Type": "application/json"})
 
-    def _pup_inv_status(self, path, data):
-        return self.inv_api.put_status(path, data, headers={"Hawkular-Tenant": "hawkular",
+    def _put_inv_status(self, path, data):
+        return self.inv_api.put_status(path, data, headers={"Hawkular-Tenant": self.tenant_id,
                                                        "Content-Type": "application/json"})
 
     def _delete_inv_status(self, path):
-        return self.inv_api.delete_status(path, headers={"Hawkular-Tenant": "hawkular"})
+        return self.inv_api.delete_status(path, headers={"Hawkular-Tenant": self.tenant_id})
 
     def _get_alerts_json(self, path):
-        return self.alerts_api.get_json(path, headers={"Hawkular-Tenant": "hawkular"})
+        return self.alerts_api.get_json(path, headers={"Hawkular-Tenant": self.tenant_id})


### PR DESCRIPTION
Recently there is big change on Hawkular-inventory API, Current version of `mgmtsyatem/hawkular.py` is using `deprecated` version of inventory API. In this PR removed all `deprecated` API's of inventory and added support for new API's
Other changes,
- Class name `Path` changed to `CanonicalPath`
- Added `to_string` property in `CanonicalPath`
- Changes in `CanonicalPath`
  * Earlier it was accassable like `path.feed`, `path.tenant`, etc.
  * path having only Id's so it has been changed as `path.feed_id`, `path.tenant_id`, `path.resource_id`, etc. All path elements ends with `_id`. For more details refer `CanonicalPath` class
- Variable `tenant_id` added, default `tenant_id` is `hawkular`
- Following `functions` are renamed
  * `_pup_inv_status` >> `_put_inv_status`
  * `edit_resource_data` >> `edit_config_data`
  * `resource_data` >> `get_config_data`
- New `functions`
  * `list_child_resource`
  * `list_operation_definition`
- Modified hawkular `mock` unit files based on new API.