### PR TITLE
Adding hawkular metrics query functions

### DIFF
--- a/mgmtsystem/hawkular.py
+++ b/mgmtsystem/hawkular.py
@@ -2,6 +2,7 @@ from base import MgmtSystemAPIBase
 from collections import namedtuple
 from rest_client import ContainerClient
 from urllib import quote as urlquote
+from enum import Enum
 
 import re
 import sys
@@ -168,6 +169,7 @@ class Hawkular(MgmtSystemAPIBase):
         self.auth = self.username, self.password
         self.inv_api = ContainerClient(hostname, self.auth, protocol, port, "hawkular/inventory")
         self.alerts_api = ContainerClient(hostname, self.auth, protocol, port, "hawkular/alerts")
+        self.metrics_api = ContainerClient(hostname, self.auth, protocol, port, "hawkular/metrics")
 
     def _check_inv_version(self, version):
         return version in self._get_inv_json('status')['Implementation-Version']
@@ -245,7 +247,11 @@ class Hawkular(MgmtSystemAPIBase):
         raise NotImplementedError('wait_vm_suspended not implemented.')
 
     def list_server_deployment(self, feed_id=None):
-        """Returns list of server deployments. Possible filters: `feed_id`"""
+        """Returns list of server deployments.
+
+        Args:
+            feed_id: Feed id of the resource (optional)
+        """
         resources = self.list_resource(feed_id=feed_id, resource_type_id='Deployment')
         deployments = []
         if resources:
@@ -254,7 +260,11 @@ class Hawkular(MgmtSystemAPIBase):
         return deployments
 
     def list_server(self, feed_id=None):
-        """Returns list of middleware servers. Possible filters: `feed_id`"""
+        """Returns list of middleware servers.
+
+          Args:
+            feed_id: Feed id of the resource (optional)
+        """
         resources = self.list_resource(feed_id=feed_id, resource_type_id='WildFly Server')
         servers = []
         if resources:
@@ -266,7 +276,12 @@ class Hawkular(MgmtSystemAPIBase):
         return servers
 
     def list_resource(self, resource_type_id, feed_id=None):
-        """Returns list of resources. Possible filters: `feed_id`, `type_id`"""
+        """Returns list of resources.
+
+          Args:
+            feed_id: Feed id of the resource (optional)
+            resource_type_id: Resource type id
+        """
         if not feed_id:
             resources = []
             for feed in self.list_feed():
@@ -277,7 +292,13 @@ class Hawkular(MgmtSystemAPIBase):
             return self._list_resource(feed_id=feed_id, resource_type_id=resource_type_id)
 
     def list_child_resource(self, feed_id, resource_id, recursive=False):
-        """Returns list of resources. Possible filters: `feed_id`, `type_id`"""
+        """Returns list of resources.
+
+          Args:
+            feed_id: Feed id of the resource
+            resource_id: Resource id
+            recursive: should be True when you want to get recursively, Default False
+        """
         if not feed_id or not resource_id:
             raise KeyError("'feed_id' and 'resource_id' are a mandatory field!")
         resources = []
@@ -294,7 +315,12 @@ class Hawkular(MgmtSystemAPIBase):
         return resources
 
     def _list_resource(self, feed_id, resource_type_id=None):
-        """Returns list of resources by provided `type_id` and `feed_id`"""
+        """Returns list of resources.
+
+         Args:
+            feed_id: Feed id of the resource
+            resource_type_id: Resource type id (optional)
+        """
         if not feed_id:
             raise KeyError("'feed_id' is a mandatory field!")
         entities = []
@@ -310,8 +336,12 @@ class Hawkular(MgmtSystemAPIBase):
         return entities
 
     def get_config_data(self, feed_id, resource_id):
-        """Returns the data/configuration information about resource by provided\
-         `feed_id` and `resource_id`."""
+        """Returns the data/configuration information about resource by provided
+
+        Args:
+            feed_id: Feed id of the resource
+            resource_id: Resource id
+         """
         if not feed_id or not resource_id:
             raise KeyError("'feed_id' and 'resource_id' are mandatory field!")
         entity_j = self._get_inv_json('entity/f;{}/r;{}/d;configuration'
@@ -331,7 +361,11 @@ class Hawkular(MgmtSystemAPIBase):
         return entities
 
     def list_resource_type(self, feed_id):
-        """Returns list of resource types by provided `feed_id`"""
+        """Returns list of resource types.
+
+         Args:
+            feed_id: Feed id of the resource type
+        """
         if not feed_id:
             raise KeyError("'feed_id' is a mandatory field!")
         entities = []
@@ -342,6 +376,12 @@ class Hawkular(MgmtSystemAPIBase):
         return entities
 
     def list_operation_definition(self, feed_id, resource_type_id):
+        """Lists operations definitions
+
+        Args:
+            feed_id: Feed id of the operation
+            resource_type_id: Resource type id of the operation
+        """
         if feed_id is None or resource_type_id is None:
             raise KeyError("'feed_id' and 'resource_type_id' are mandatory fields!")
         res_j = self._get_inv_json('traversal/f;{}/rt;{}/type=ot'.format(feed_id, resource_type_id))
@@ -352,7 +392,11 @@ class Hawkular(MgmtSystemAPIBase):
         return operations
 
     def list_server_datasource(self, feed_id=None):
-        """Returns list of datasources. Possible filters: `feed_id`"""
+        """Returns list of datasources.
+
+         Args:
+             feed_id: Feed id of the datasource (optional)
+        """
         resources = self.list_resource(feed_id=feed_id, resource_type_id='Datasource')
         datasources = []
         if resources:
@@ -361,8 +405,11 @@ class Hawkular(MgmtSystemAPIBase):
         return datasources
 
     def edit_config_data(self, resource_data, **kwargs):
-        """Edits the data.value information for resource by provided\
-         `feed_id` and `resource_id`."""
+        """Edits the data.value information for resource by provided
+
+        Args:
+            resource_data: Resource data
+        """
         if not isinstance(resource_data, ResourceData) or not resource_data.value:
             raise KeyError(
                 "'resource_data' should be ResourceData with 'value' attribute")
@@ -373,8 +420,13 @@ class Hawkular(MgmtSystemAPIBase):
         return r
 
     def create_resource(self, resource, resource_data, resource_type, **kwargs):
-        """Creates new resource and creates it's data by provided\
-         `feed_id` and `resource_id`."""
+        """Creates new resource and creates it's data by provided
+        Args:
+            resource: resource
+            kwargs: feed_id, resource_id and required fields
+            resource_data: Resource data
+            resource_type: Resource type
+        """
         if not isinstance(resource, Resource):
             raise KeyError("'resource' should be an instance of Resource")
         if not isinstance(resource_data, ResourceData) or not resource_data.value:
@@ -400,16 +452,25 @@ class Hawkular(MgmtSystemAPIBase):
         return r
 
     def delete_resource(self, feed_id, resource_id):
-        """Removed the resource by provided `feed_id` and `resource_id`."""
+        """Removed a resource.
+        Args:
+            feed_id: Feed id of the data source
+            resource_id: Resource id of the datasource
+        """
         if not feed_id or not resource_id:
             raise KeyError("'feed_id' and 'resource_id' are mandatory fields!")
         r = self._delete_inv_status('entity/f;{}/r;{}'.format(feed_id, resource_id))
         return r
 
     def list_event(self, start_time=0, end_time=sys.maxsize):
-        """Returns the list of events filtered by provided start time and end time.
-        Or lists all events if no argument provided.
-        This information is wrapped into Event."""
+        """Returns the list of events.
+        Filtered by provided start time and end time. Or lists all events if no argument provided.
+        This information is wrapped into Event.
+
+         Args:
+             start_time: Start time as timestamp
+             end_time: End time as timestamp
+         """
         entities = []
         entities_j = self._get_alerts_json('events?startTime={}&endTime={}'
                                      .format(start_time, end_time))
@@ -438,3 +499,322 @@ class Hawkular(MgmtSystemAPIBase):
 
     def _get_alerts_json(self, path):
         return self.alerts_api.get_json(path, headers={"Hawkular-Tenant": self.tenant_id})
+
+    def _get_metrics_json(self, path, params=None):
+        return self.metrics_api.get_json(path,
+                                         headers={"Hawkular-Tenant": self.tenant_id},
+                                         params=params)
+
+    def status_alerts(self):
+        """returns status of alerts service"""
+        return self._get_alerts_json(path='status')
+
+    def status_inventory(self):
+        """Returns status of inventory service"""
+        return self._get_inv_json(path='status')
+
+    def status_metrics(self):
+        """Returns status of metrics service"""
+        return self._get_metrics_json(path='status')
+
+    def status(self):
+        """Returns status of alerts, inventory and metrics services"""
+        return {
+            'alerts': self.status_alerts(),
+            'inventory': self.status_inventory(),
+            'metrics': self.status_metric()
+        }
+
+    def list_metric_availability_feed(self, feed_id, **kwargs):
+        """Returns list of DataPoint of a feed
+        Args:
+            feed_id: Feed id of the metric resource
+            kwargs: Refer ``list_metric_availability``
+        """
+        metric_id = "hawkular-feed-availability-{}".format(feed_id)
+        return self.list_metric_availability(metric_id=metric_id, **kwargs)
+
+    def list_metric_availability_server(self, feed_id, server_id, **kwargs):
+        """Returns list of `DataPoint` of a server
+        Args:
+            feed_id: Feed id of the server
+            server_id: Server id
+            kwargs: Refer ``list_metric_availability``
+        """
+        metric_id = "AI~R~[{}/{}~~]~AT~Server Availability~Server Availability" \
+            .format(feed_id, server_id)
+        return self.list_metric_availability(metric_id=metric_id, **kwargs)
+
+    def list_metric_availability_deployment(self, feed_id, server_id, resource_id, **kwargs):
+        """Returns list of `DataPoint` of a deployment
+        Args:
+            feed_id: Feed id of the deployment
+            server_id: Server id of the deployment
+            resource_id: deployment id
+            kwargs: Refer ``list_metric_availability``
+        """
+        metric_id = "AI~R~[{}/{}~/deployment={}]~AT~Deployment Status~Deployment Status" \
+            .format(feed_id, server_id, resource_id)
+        return self.list_metric_availability(metric_id=metric_id, **kwargs)
+
+    def list_metric_availability(self, metric_id, **kwargs):
+        """Returns list of `DataPoint` of a metric
+        Args:
+            metric_id: Metric id
+            kwargs: refer optional query params and query type
+
+        Optional query params:
+            start: timestamp, Defaults to now: 8 hours
+            end: timestamp, Defaults to now
+            buckets: Total number of buckets
+            bucketDuration: Bucket duration
+            distinct: Set to true to return only distinct, contiguous values
+            limit: Limit the number of data points returned
+            order: Data point sort order, based on timestamp [values: ASC, DESC]
+
+        Query type:
+            raw: set True when you want to get raw data, Default False which returns stats
+        """
+        prefix_id = "availability/{}".format(urlquote(metric_id, safe=''))
+        return self._list_metric_data(prefix_id=prefix_id, **kwargs)
+
+    def list_metric_gauge_datasource(self, feed_id, server_id, resource_id, metric_enum, **kwargs):
+        """Returns list of NumericBucketPoint of datasource metric
+            Args:
+                feed_id: feed id of the datasource
+                server_id: server id of the datasource
+                resource_id: resource id, here which is datasource id
+                metric_enum: Any one of *DS_* Enum value from ``MetricEnumGauge``
+                kwargs: Refer ``list_metric_gauge``
+            """
+        if not isinstance(metric_enum, MetricEnumGauge):
+            raise KeyError("'metric_enum' should be a type of 'MetricEnumGauge' Enum class")
+        return self._list_metric_gauge_datasource(feed_id=feed_id, server_id=server_id,
+                                                  resource_id=resource_id,
+                                                  metric_type=metric_enum.metric_type,
+                                                  metric_sub_type=metric_enum.sub_type, **kwargs)
+
+    def _list_metric_gauge_datasource(self, feed_id, server_id, resource_id, metric_type,
+                                      metric_sub_type, **kwargs):
+        metric_id = "MI~R~[{}/{}~/subsystem=datasources/data-source={}]~MT~{}~{}" \
+            .format(feed_id, server_id, resource_id, metric_type, metric_sub_type)
+        return self.list_metric_gauge(metric_id=metric_id, **kwargs)
+
+    def list_metric_gauge_server(self, feed_id, server_id, metric_enum, **kwargs):
+        """Returns list of `NumericBucketPoint` of server metric
+            Args:
+                feed_id: feed id of the server
+                server_id: server id
+                metric_enum: Any one of *SVR_* ``Enum`` value from ``MetricEnumGauge``
+                kwargs: Refer ``list_metric_gauge``
+            """
+        if not isinstance(metric_enum, MetricEnumGauge):
+            raise KeyError("'metric_enum' should be a type of 'MetricEnumGauge' Enum class")
+        return self._list_metric_gauge_server(feed_id=feed_id, server_id=server_id,
+                                              metric_type=metric_enum.metric_type,
+                                              metric_sub_type=metric_enum.sub_type, **kwargs)
+
+    def _list_metric_gauge_server(self, feed_id, server_id, metric_type, metric_sub_type, **kwargs):
+        metric_id = "MI~R~[{}/{}~~]~MT~{}~{}".format(feed_id, server_id,
+                                                     metric_type, metric_sub_type)
+        return self.list_metric_gauge(metric_id=metric_id, **kwargs)
+
+    def list_metric_gauge(self, metric_id, **kwargs):
+        """Returns list of `NumericBucketPoint` of a metric
+            Args:
+                metric_id: Metric id
+                kwargs: Refer optional query params and query type
+
+            Optional query params:
+                start: timestamp, Defaults to now: 8 hours
+                end: timestamp, Defaults to now
+                buckets: Total number of buckets
+                bucketDuration: Bucket duration
+                distinct: Set to true to return only distinct, contiguous values
+                limit: Limit the number of data points returned
+                order: Data point sort order, based on timestamp [values: ASC, DESC]
+
+            Query type:
+                raw: set True when you want to get raw data, Default False which returns stats
+                rate: set True when you want rate data default False
+                stats: return stats data default True
+            """
+        prefix_id = "gauges/{}".format(urlquote(metric_id, safe=''))
+        return self._list_metric_data(prefix_id=prefix_id, **kwargs)
+
+    def list_metric_counter_server(self, feed_id, server_id, metric_enum, **kwargs):
+        """Returns list of `NumericBucketPoint` of server metric
+            Args:
+                feed_id: feed id of the server
+                server_id: server id
+                metric_enum: Any one of *SVR_* ``Enum`` value from ``MetricEnumCounter``
+                kwargs: Refer ``list_metric_counter``
+            """
+        if not isinstance(metric_enum, MetricEnumCounter):
+            raise KeyError("'metric_enum' should be a type of 'MetricEnumCounter' Enum class")
+        return self._list_metric_counter_server(feed_id=feed_id, server_id=server_id,
+                                              metric_type=metric_enum.metric_type,
+                                              metric_sub_type=metric_enum.sub_type, **kwargs)
+
+    def _list_metric_counter_server(self,
+                                   feed_id, server_id, metric_type, metric_sub_type, **kwargs):
+        if MetricEnumCounter.SVR_TXN_NUMBER_OF_TRANSACTIONS.metric_type == metric_type:
+            metric_id = "MI~R~[{}/{}~/subsystem=transactions]~MT~{}~{}"\
+                .format(feed_id, server_id, metric_type, metric_sub_type)
+        else:
+            metric_id = "MI~R~[{}/{}~~]~MT~{}~{}".format(feed_id, server_id, metric_type,
+                                                         metric_sub_type)
+        return self.list_metric_counter(metric_id=metric_id, **kwargs)
+
+    def list_metric_counter_deployment(self,
+                                       feed_id, server_id, resource_id, metric_enum, **kwargs):
+        """Returns list of `NumericBucketPoint` of server metric
+            Args:
+                feed_id: feed id of the deployment
+                server_id: server id of the deployment
+                resource_id: resource id, that's deployment id
+                metric_enum: Any one of *DEP_* ``Enum`` value from ``MetricEnumCounter``
+                kwargs: Refer ``list_metric_counter``
+            """
+        if not isinstance(metric_enum, MetricEnumCounter):
+            raise KeyError("'metric_enum' should be a type of 'MetricEnumCounter' Enum class")
+        return self._list_metric_counter_deployment(feed_id=feed_id, server_id=server_id,
+                                                    resource_id=resource_id,
+                                                    metric_type=metric_enum.metric_type,
+                                                    metric_sub_type=metric_enum.sub_type, **kwargs)
+
+    def _list_metric_counter_deployment(self, feed_id, server_id, resource_id,
+                                       metric_type, metric_sub_type, **kwargs):
+        metric_id = "MI~R~[{}/{}~/deployment={}]~MT~{}~{}"\
+            .format(feed_id, server_id, resource_id, metric_type, metric_sub_type)
+        return self.list_metric_counter(metric_id=metric_id, **kwargs)
+
+    def list_metric_counter(self, metric_id, **kwargs):
+        """Returns list of `NumericBucketPoint` of a metric
+            Args:
+                metric_id: metric id
+                kwargs: Refer optional query params and query type
+
+            Optional query params:
+                start: timestamp, Defaults to now: 8 hours
+                end: timestamp, Defaults to now
+                buckets: Total number of buckets
+                bucketDuration: Bucket duration
+                distinct: Set to true to return only distinct, contiguous values
+                limit: Limit the number of data points returned
+                order: Data point sort order, based on timestamp [values: ASC, DESC]
+
+            Query type:
+                raw: set True when you want to get raw data, Default False which returns stats
+                rate: set True when you want rate data default False
+                stats: return stats data default True
+            """
+        prefix_id = "counters/{}".format(urlquote(metric_id, safe=''))
+        return self._list_metric_data(prefix_id=prefix_id, **kwargs)
+
+    def list_metric_availability_definition(self):
+        """Lists all availability type metric definitions"""
+        return self._get_metrics_json(path='availability')
+
+    def list_metric_gauge_definition(self):
+        """Lists all gauge type metric definitions"""
+        return self._get_metrics_json(path='gauges')
+
+    def list_metric_counter_definition(self):
+        """Lists all counter type metric definitions"""
+        return self._get_metrics_json(path='counters')
+
+    def list_metric_definition(self):
+        """Lists all metric definitions"""
+        return self._get_metrics_json(path='metrics')
+
+    def _list_metric_data(self, prefix_id, **kwargs):
+        params = {
+            'start': kwargs.get('start', None),
+            'end': kwargs.get('end', None),
+            'bucketDuration': kwargs.get('bucketDuration', None),
+            'buckets': kwargs.get('buckets', None),
+            'percentiles': kwargs.get('percentiles', None),
+            'limit': kwargs.get('limit', None),
+            'order': kwargs.get('order', None),
+        }
+        raw = kwargs.get('raw', False)
+        rate = kwargs.get('rate', False)
+        if not raw and params['bucketDuration'] is None and params['buckets'] is None:
+            raise KeyError("Either the 'buckets' or 'bucketDuration' parameter must be used")
+        if rate:
+            return self._get_metrics_json(path='{}/rate/stats'.format(prefix_id), params=params)
+        elif raw:
+            return self._get_metrics_json(path='{}/raw'.format(prefix_id), params=params)
+        else:
+            return self._get_metrics_json(path='{}/stats'.format(prefix_id), params=params)
+
+
+class MetricEnum(Enum):
+    """Enum to define Metrics type and sub type. This is base for all Enum types in metrics"""
+    def __init__(self, metric_type, sub_type):
+        self.metric_type = metric_type  # metric type
+        self.sub_type = sub_type  # sub type
+
+
+class MetricEnumGauge(MetricEnum):
+    """Enum to define Gauge metric types and sub types"""
+    DS_POOL_ACTIVE_COUNT = ("Datasource Pool Metrics", "Active Count")
+    DS_POOL_AVAILABLE_COUNT = ("Datasource Pool Metrics", "Available Count")
+    DS_POOL_AVERAGE_BLOCKING_TIME = ("Datasource Pool Metrics", "Average Blocking Time")
+    DS_POOL_AVERAGE_CREATION_TIME = ("Datasource Pool Metrics", "Average Creation Time")
+    DS_POOL_AVERAGE_GET_TIME = ("Datasource Pool Metrics", "Average Get Time")
+    DS_POOL_BLOCKING_FAILURE_COUNT = ("Datasource Pool Metrics", "Blocking Failure Count")
+    DS_POOL_CREATED_COUNT = ("Datasource Pool Metrics", "Created Count")
+    DS_POOL_DESTROYED_COUNT = ("Datasource Pool Metrics", "Destroyed Count")
+    DS_POOL_IDLE_COUNT = ("Datasource Pool Metrics", "Idle Count")
+    DS_POOL_IN_USE_COUNT = ("Datasource Pool Metrics", "In Use Count")
+    DS_POOL_MAX_CREATION_TIME = ("Datasource Pool Metrics", "Max Creation Time")
+    DS_POOL_MAX_GET_TIME = ("Datasource Pool Metrics", "Max Get Time")
+    DS_POOL_MAX_USED_COUNT = ("Datasource Pool Metrics", "Max Used Count")
+    DS_POOL_MAX_WAIT_COUNT = ("Datasource Pool Metrics", "Max Wait Count")
+    DS_POOL_MAX_WAIT_TIME = ("Datasource Pool Metrics", "Max Wait Time")
+    DS_POOL_TIMED_OUT = ("Datasource Pool Metrics", "Timed Out")
+    DS_POOL_TOTAL_BLOCKING_TIME = ("Datasource Pool Metrics", "Total Blocking Time")
+    DS_POOL_TOTAL_CREATION_TIME = ("Datasource Pool Metrics", "Total Creation Time")
+    DS_POOL_TOTAL_GET_TIME = ("Datasource Pool Metrics", "Total Get Time")
+    DS_POOL_WAIT_COUNT = ("Datasource Pool Metrics", "Wait Count")
+    SVR_MEM_HEAP_COMMITTED = ("WildFly Memory Metrics", "Heap Committed")
+    SVR_MEM_HEAP_MAX = ("WildFly Memory Metrics", "Heap Max")
+    SVR_MEM_HEAP_USED = ("WildFly Memory Metrics", "Heap Used")
+    SVR_MEM_NON_HEAP_COMMITTED = ("WildFly Memory Metrics", "NonHeap Committed")
+    SVR_MEM_NON_HEAP_USED = ("WildFly Memory Metrics", "NonHeap Used")
+    SVR_TH_THREAD_COUNT = ("WildFly Threading Metrics", "Thread Count")
+    SVR_WEB_AGGREGATED_ACTIVE_WEB_SESSIONS = \
+        ("WildFly Aggregated Web Metrics", "Aggregated Active Web Sessions")
+    SVR_WEB_AGGREGATED_MAX_ACTIVE_WEB_SESSIONS = \
+        ("WildFly Aggregated Web Metrics", "Aggregated Max Active Web Sessions")
+
+
+class MetricEnumCounter(MetricEnum):
+    """Enum Counter metric types and sub types"""
+    DEP_UTM_EXPIRED_SESSIONS = ("Undertow Metrics", "Expired Sessions")
+    DEP_UTM_REJECTED_SESSIONS = ("Undertow Metrics", "Rejected Sessions")
+    DEP_UTM_SESSIONS_CREATED = ("Undertow Metrics", "Sessions Created")
+    SVR_MEM_ACCUMULATED_GC_DURATION = ("WildFly Memory Metrics", "Accumulated GC Duration")
+    SVR_TXN_NUMBER_OF_ABORTED_TRANSACTIONS = \
+        ("Transactions Metrics", "Number of Aborted Transactions")
+    SVR_TXN_NUMBER_OF_APPLICATION_ROLLBACKS = \
+        ("Transactions Metrics", "Number of Application Rollbacks")
+    SVR_TXN_NUMBER_OF_COMMITTED_TRANSACTIONS = \
+        ("Transactions Metrics", "Number of Committed Transactions")
+    SVR_TXN_NUMBER_OF_HEURISTICS = ("Transactions Metrics", "Number of Heuristics")
+    SVR_TXN_NUMBER_OF_NESTED_TRANSACTIONS = \
+        ("Transactions Metrics", "Number of Nested Transactions")
+    SVR_TXN_NUMBER_OF_RESOURCE_ROLLBACKS = ("Transactions Metrics", "Number of Resource Rollbacks")
+    SVR_TXN_NUMBER_OF_TIMED_OUT_TRANSACTIONS = \
+        ("Transactions Metrics", "Number of Timed Out Transactions")
+    SVR_TXN_NUMBER_OF_TRANSACTIONS = ("Transactions Metrics", "Number of Transactions")
+    SVR_WEB_AGGREGATED_EXPIRED_WEB_SESSIONS = \
+        ("WildFly Aggregated Web Metrics", "Aggregated Expired Web Sessions")
+    SVR_WEB_AGGREGATED_REJECTED_WEB_SESSIONS = \
+        ("WildFly Aggregated Web Metrics", "Aggregated Rejected Web Sessions")
+    SVR_WEB_AGGREGATED_SERVLET_REQUEST_COUNT = \
+        ("WildFly Aggregated Web Metrics", "Aggregated Servlet Request Count")
+    SVR_WEB_AGGREGATED_SERVLET_REQUEST_TIME = \
+        ("WildFly Aggregated Web Metrics", "Aggregated Servlet Request Time")

--- a/mgmtsystem/rest_client.py
+++ b/mgmtsystem/rest_client.py
@@ -58,8 +58,8 @@ class ContainerClient(object):
         r = self.raw_get(path)
         return (r.status_code, r.json() if r.ok else None)
 
-    def get_json(self, path, headers=None):
-        r = self.raw_get(path, headers)
+    def get_json(self, path, headers=None, params=None):
+        r = self.raw_get(path, headers, params)
         return (r.json() if r.ok else None)
 
     def put_status(self, path, data, headers=None):
@@ -74,10 +74,13 @@ class ContainerClient(object):
         r = self.raw_delete(path, headers)
         return r.ok
 
-    def raw_get(self, path, headers=None):
+    def raw_get(self, path, headers=None, params=None):
         return requests.get(
-            os.path.join(self.api_entry, path), auth=self.auth, verify=self.verify,
-            headers=headers)
+            os.path.join(self.api_entry, path),
+            auth=self.auth,
+            verify=self.verify,
+            headers=headers,
+            params=params)
 
     def raw_put(self, path, data, headers=None):
         return requests.put(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 boto
+enum34
 fauxfactory>=2.0.7
 google-api-python-client
 ovirt-engine-sdk-python


### PR DESCRIPTION
Adding support for hawkular metrics query functions

Supports for metrics types
- `availability`
- `gauges`
- `counter`

### New functions:

#### Status:
- `status_alerts` - Returns `alerts` service status
- `status_inventory` - Returns `inventory` service status
- `status_metrics` - Returns `metrics` service status
- `status` - Returns all services status

#### Metrics definition
- `list_metric_definition` - returns list of all metric definitions
- `list_metric_availability_definition` - returns list of all `availability` metric definitions
- `list_metric_gauge_definition` - returns list of all `gauge` metric definitions
- `list_metric_counter_definition` - returns list of all `counter` metric definitions

#### Metrics data
- `list_metric_availability_feed` - Returns list of availability metrics for a feed
- `list_metric_availability_server` - Returns list of availability metrics for a server
- `list_metric_availability_deployment` - Returns list of availability metrics for a deployment
- `list_metric_availability` -  Returns list of availability metrics for a metric
- `list_metric_gauge_datasource` - returns gauge metric data of a datasource
- `list_metric_gauge_server` -  returns gauge metric data of a server
- `list_metric_gauge` - returns gauge metric data of a metric
- `list_metric_counter_server` - returns counter metric data of a server
- `list_metric_counter_deployment` - returns counter metric data of a deployment
- `list_metric_counter` - returns counter metric data of a metric

**Optional query params for metrics data**

- `start` - timestamp, Defaults to now - 8 hours
- `end` - timestamp, Defaults to now
- `buckets` - Total number of buckets
- `bucketDuration` - Bucket duration
- `distinct` - Set to true to return only distinct, contiguous values
- `limit` - Limit the number of data points returned
- `order` - Data point sort order, based on timestamp [values: `ASC`, `DESC`]
- Query type:
  - Default : `stats`
  - for `raw` set `raw=True`
  - for `rate` set `rate=True`


**Example:**
```
from mgmtsystem.hawkular import Hawkular
haw = Hawkular(hostname="my-host", port="8080", username="jdoe", password="password")

# To get server `Heap used` for last 8 hours with 2 hours duration (guage metrics)
from mgmtsystem.hawkular import MetricEnumGauge as meg
haw.list_metric_gauge_server(feed_id='b476e289-b645-41c0-9d03-0b91a0521d5a', bucketDuration='2h', server_id='Local', metric_enum=meg.SVR_MEM_HEAP_USED)

# To get deployment `Sessions Created` (counter metrics) for last 8 hours with 30 minutes duration
from mgmtsystem.hawkular import MetricEnumCounter as mec
haw.list_metric_counter_deployment(feed_id='b476e289-b645-41c0-9d03-0b91a0521d5a', bucketDuration='30mn', server_id='Local', resource_id='hawkular-rest-api.war', metric_enum=mec.DEP_UTM_SESSIONS_CREATED)

# Get RAW data of server gauge data
haw.list_metric_gauge_server(feed_id='b476e289-b645-41c0-9d03-0b91a0521d5a', server_id='Local', metric_enum=meg.SVR_MEM_HEAP_USED, raw=True)
```