### PR TITLE
Minor Tweak - Added delete_vm call to delete_stack

### DIFF
--- a/mgmtsystem/azure.py
+++ b/mgmtsystem/azure.py
@@ -297,6 +297,7 @@ class AzureSystem(MgmtSystemAPIBase):
             -DeploymentName \"{stack}\" -Force
             }}
             """.format(rg=resource_group or self.resource_group, stack=stack_name))
+        self.delete_vm(stack_name, resource_group or self.resource_group)
         return True
 
     def deploy_template(self, template, vm_name=None, **vm_settings):


### PR DESCRIPTION
Delete stack for EC2 and OpenStack remove the VM automatically.  In Azure, it has to be explicit.  I just added a quick reference to an existing method and tested it locally.  Need this merged in advance of a new integration PR which is ready.