### PR TITLE
add some deploy_template flexibilty for vmw and osp

### DIFF
--- a/mgmtsystem/openstack.py
+++ b/mgmtsystem/openstack.py
@@ -449,8 +449,11 @@ class OpenstackSystem(MgmtSystemAPIBase):
         power_on = kwargs.pop("power_on", True)
         nics = []
         timeout = kwargs.pop('timeout', 900)
+
         if 'flavour_name' in kwargs:
             flavour = self.api.flavors.find(name=kwargs['flavour_name'])
+        elif 'instance_type' in kwargs:
+            flavour = self.api.flavors.find(name=kwargs['instance_type'])
         elif 'flavour_id' in kwargs:
             flavour = self.api.flavors.find(id=kwargs['flavour_id'])
         else:

--- a/mgmtsystem/virtualcenter.py
+++ b/mgmtsystem/virtualcenter.py
@@ -501,7 +501,7 @@ class VMWareSystem(MgmtSystemAPIBase):
 
     def clone_vm(self, source, destination, resourcepool=None, datastore=None, power_on=True,
                  sparse=False, template=False, provision_timeout=1800, progress_callback=None,
-                 allowed_datastores=None, cpu=None, ram=None):
+                 allowed_datastores=None, cpu=None, ram=None, **kwargs):
         try:
             if mobs.VirtualMachine.get(self.api, name=destination).name == destination:
                 raise Exception("VM already present!")


### PR DESCRIPTION
Found another name for a flavor for osp provisioning, vmw needed to add
kwargs to ignore extra parameters being passed to the template that we
not needed.