### PR TITLE
deploy gce instances with ssh public key, when specified.

### DIFF
--- a/mgmtsystem/google.py
+++ b/mgmtsystem/google.py
@@ -342,6 +342,13 @@ class GoogleCloudSystem(MgmtSystemAPIBase):
             }
         }
 
+        if kwargs.get('ssh_key', None):
+            ssh_keys = {
+                'key': 'ssh-keys',
+                'value': kwargs.get('ssh_key', None)
+            }
+            config['metadata']['items'].append(ssh_keys)
+
         operation = self._instances.insert(
             project=self._project, zone=self._zone, body=config).execute()
         wait_for(lambda: self._nested_operation_wait(operation['name']), delay=0.5,


### PR DESCRIPTION
  * when ssh public key is specified, deploy gce instance with ssh-key metadata. ssh key is important to access gce instance, use private key to establish ssh connection.