### PR TITLE
Added ability to query OSP nodes via Ironic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ google-api-python-client
 ovirt-engine-sdk-python<4.0.0
 psphere
 python-cinderclient
+python-ironicclient
 python-keystoneclient
 python-novaclient<7.0.0
 python-heatclient


### PR DESCRIPTION
Querying via noa does not show the inactive nodes, so Ironic is required.

Example:

```
In [1]: from utils.providers import get_mgmt
In [2]: p = get_mgmt('provider key')
In [3]: p.list_node()
Out[3]: 
[Node(uuid=u'4ff82be7-be40-48c7-81ea-63dc059eb7d3', name=None, power_state=u'power off', provision_state=u'available'),
 Node(uuid=u'607cc79c-5d30-42c4-bd76-e723d510e7a2', name=u'overcloud-controller-0', power_state=u'power on', provision_state=u'active'),
 Node(uuid=u'694b9a1a-b687-44e6-8c73-67982b8c4317', name=u'overcloud-compute-0', power_state=u'power on', provision_state=u'active')]
```

The first entry is a node that cannot be queried via nova because it is not "plugged in" so Nova does not see it.

Required for @rrasouli