### PR TITLE
Added list_image_openshift() to collect images from Openshift

### DIFF
--- a/mgmtsystem/openshift.py
+++ b/mgmtsystem/openshift.py
@@ -100,3 +100,10 @@ class Openshift(Kubernetes):
             entity = Template(meta['name'], meta['namespace'])
             entities.append(entity)
         return entities
+    
+    def list_image_openshift(self):
+        entities = []
+        entities_j = self.o_api.get('image')[1]['items']
+        for entity_j in entities_j:
+            entities.append(entity_j['metadata'])
+        return entities


### PR DESCRIPTION
list_image_openshift() is used to gather all images from Openshift, excluding those that are created by running pods