### PR TITLE
[RFR]EMERGENCY fix of delete_vm due to Azure API change today

### DIFF
--- a/mgmtsystem/azure.py
+++ b/mgmtsystem/azure.py
@@ -153,7 +153,6 @@ class AzureSystem(MgmtSystemAPIBase):
 
     def delete_vm(self, vm_name, resource_group=None):
         self.logger.info("Begin delete_vm {}".format(vm_name))
-        vhd_endpoint = self.get_vm_vhd(vm_name, resource_group or self.resource_group)
         self.run_script(
             """
             Invoke-Command -scriptblock {{
@@ -162,9 +161,7 @@ class AzureSystem(MgmtSystemAPIBase):
             Remove-AzureRmPublicIpAddress -Name \"{vm}\" -ResourceGroupName \"{rg}\" -Force
             }}
             """.format(rg=resource_group or self.resource_group, vm=vm_name), True)
-
-        vhd_name = os.path.split(urlparse.urlparse(vhd_endpoint).path)[1]
-        self.remove_blob_image(vhd_name)
+        self.remove_blob_image(vm_name + '.vhd')
 
     def list_vm(self):
         self.logger.info("Attempting to List Azure VMs")


### PR DESCRIPTION
Azure changed the API today and moved the storage text to another module.  This will work for 99+% of the VMs and all of the automation VMs while Dan and I investigate what else may have broken.

Currently it's leaving hundreds of running VMs and they're being created faster than the clean can get rid of them.

@dajohnso @mshriver @mfalesni 