### PR TITLE
[RFR]Force VM delete to catch weird errors

### DIFF
--- a/wrapanapi/scvmm.py
+++ b/wrapanapi/scvmm.py
@@ -126,7 +126,7 @@ class SCVMMSystem(WrapanapiAPIBase):
         finally:
             script = """
                 $VM = Get-SCVirtualMachine -Name \"{vm_name}\" -VMMServer $scvmm_server
-                Remove-SCVirtualMachine -VM $VM
+                Remove-SCVirtualMachine -VM $VM -Force
             """.format(vm_name=vm_name)
             self.logger.info("Deleting SCVMM VM {}".format(vm_name))
             self.run_script(script)


### PR DESCRIPTION
Some VMs in extreme error conditions were not being deleted in cleanup.  By adding the -Force flag, like in delete_template, this will remove even the VMs which are in an error condition.
