### PR TITLE
[1LP][RFR] Fix an issue with clone_vm not expecting None

### DIFF
--- a/wrapanapi/virtualcenter.py
+++ b/wrapanapi/virtualcenter.py
@@ -595,8 +595,10 @@ class VMWareSystem(WrapanapiAPIBase):
     def clone_vm(self, source, destination, resourcepool=None, datastore=None, power_on=True,
                  sparse=False, template=False, provision_timeout=1800, progress_callback=None,
                  allowed_datastores=None, cpu=None, ram=None, **kwargs):
+        """Clone a VM"""
         try:
-            if self._get_obj(vim.VirtualMachine, name=destination).name == destination:
+            vm = self._get_obj(vim.VirtualMachine, name=destination)
+            if vm and vm.name == destination:
                 raise Exception("VM already present!")
         except VMInstanceNotFound:
             pass


### PR DESCRIPTION
In the clone_vm method of the vSphere class, it was not expecting None when a VM doesn't exist. Changed it to expect a None.