### PR TITLE
[1LP][RFR] Fix an issue with non-existant VMs being handled incorrectly

### DIFF
--- a/wrapanapi/virtualcenter.py
+++ b/wrapanapi/virtualcenter.py
@@ -276,8 +276,7 @@ class VMWareSystem(WrapanapiAPIBase):
         Returns: A boolean, ``True`` if the vm exists, ``False`` if not.
         """
         try:
-            self._get_vm(name)
-            return True
+            return self._get_vm(name) is not None
         except VMInstanceNotFound:
             return False
 

--- a/wrapanapi/virtualcenter.py
+++ b/wrapanapi/virtualcenter.py
@@ -606,7 +606,7 @@ class VMWareSystem(WrapanapiAPIBase):
             progress_callback = partial(self._progress_log_callback, self.logger,
                 source, destination)
 
-        source_template = self._get_obj(vim.VirtualMachine, name=source)
+        source_template = self._get_vm(source)
 
         vm_clone_spec = vim.VirtualMachineCloneSpec()
         vm_reloc_spec = vim.VirtualMachineRelocateSpec()


### PR DESCRIPTION
clone_vm was using _get_obj() for getting a VM which simply returns None if the object doesn't exist. Changed it to use _get_vm() so that an exception is raised. Also just tighten up the logic in does_vm_exist() a little.