### PR TITLE
[RFR] Update virtualcenter.get_vm_datastore_path and vm_status

### DIFF
--- a/wrapanapi/virtualcenter.py
+++ b/wrapanapi/virtualcenter.py
@@ -515,9 +515,10 @@ class VMWareSystem(WrapanapiAPIBase):
 
     def get_vm_datastore_path(self, vm_name, vm_config_datastore):
         vm = self._get_vm(vm_name)
-        datastore_url = [str(datastore['url']) for datastore in vm.config.datastoreUrl
-                         if datastore['name'] in vm_config_datastore]
-        return datastore_url[0]
+        datastore_url = [str(datastore.url)
+                         for datastore in vm.config.datastoreUrl
+                         if datastore.name in vm_config_datastore]
+        return datastore_url.pop()
 
     def get_vm_config_files_path(self, vm_name):
         vm = self._get_vm(vm_name)

--- a/wrapanapi/virtualcenter.py
+++ b/wrapanapi/virtualcenter.py
@@ -500,7 +500,7 @@ class VMWareSystem(WrapanapiAPIBase):
         pass
 
     def vm_status(self, vm_name):
-        return self._get_vm(vm_name, force=True).runtime.powerState
+        return str(self._get_vm(vm_name, force=True).runtime.powerState)
 
     def vm_creation_time(self, vm_name):
         vm = self._get_vm(vm_name)


### PR DESCRIPTION
vm.config.datastoreUrl returns an object, use \_\_getattribute\_\_ instead
of \_\_getitem\_\_

Also vm_status was returning a vim.VirtualMachine.PowerState object, return a string instead. Although its a wrapper for string, it breaks threaded applications that are trying to pickle some of these values.