### PR TITLE
[RFR] Standardize vm_creation_time

### DIFF
--- a/wrapanapi/azure.py
+++ b/wrapanapi/azure.py
@@ -12,7 +12,7 @@ from cStringIO import StringIO
 from contextlib import contextmanager
 from textwrap import dedent
 
-import tzlocal
+import pytz
 from lxml import etree
 from wait_for import wait_for
 
@@ -329,7 +329,7 @@ class AzureSystem(WrapanapiAPIBase):
             raise VMCreationDateError('No LastModified date found for instance {}'.format(vm_name))
         create_time = datetime.strptime(str(vhd_last_modified), '%Y-%m-%dT%H:%M:%S %p')
         self.logger.info("VM last edit time based on vhd =  {}".format(str(create_time)))
-        return tzlocal.get_localzone().fromutc(create_time).replace(tzinfo=None)
+        return create_time.replace(tzinfo=pytz.UTC)
 
     def create_netsec_group(self, group_name, resource_group):
         self.logger.info("Attempting to Create New Azure Security Group {}".format(group_name))

--- a/wrapanapi/azure.py
+++ b/wrapanapi/azure.py
@@ -20,7 +20,6 @@ from base import WrapanapiAPIBase
 from exceptions import VMInstanceNotFound, ActionTimedOutError, VMCreationDateError
 
 
-
 class AzureSystem(WrapanapiAPIBase):
     """This class is used to connect to Microsoft Azure Portal via PowerShell AzureRM Module
     """

--- a/wrapanapi/azure.py
+++ b/wrapanapi/azure.py
@@ -12,11 +12,13 @@ from cStringIO import StringIO
 from contextlib import contextmanager
 from textwrap import dedent
 
-from exceptions import VMInstanceNotFound, ActionTimedOutError
+import tzlocal
 from lxml import etree
 from wait_for import wait_for
 
 from base import WrapanapiAPIBase
+from exceptions import VMInstanceNotFound, ActionTimedOutError, VMCreationDateError
+
 
 
 class AzureSystem(WrapanapiAPIBase):
@@ -323,9 +325,11 @@ class AzureSystem(WrapanapiAPIBase):
                        vhd_blob=vhd_name), True)
         vhd_last_modified = etree.parse(StringIO(self.clean_azure_xml(data))).getroot().xpath(
             "./Object/Property[@Name='LastModified']/text()")
-        create_time = datetime.strptime(str(vhd_last_modified), '[\'%m/%d/%Y %H:%M:%S %p +00:00\']')
+        if not vhd_last_modified:
+            raise VMCreationDateError('No LastModified date found for instance {}'.format(vm_name))
+        create_time = datetime.strptime(str(vhd_last_modified), '%Y-%m-%dT%H:%M:%S %p')
         self.logger.info("VM last edit time based on vhd =  {}".format(str(create_time)))
-        return create_time
+        return tzlocal.get_localzone().fromutc(create_time).replace(tzinfo=None)
 
     def create_netsec_group(self, group_name, resource_group):
         self.logger.info("Attempting to Create New Azure Security Group {}".format(group_name))

--- a/wrapanapi/azure.py
+++ b/wrapanapi/azure.py
@@ -327,9 +327,9 @@ class AzureSystem(WrapanapiAPIBase):
             "./Object/Property[@Name='LastModified']/text()")
         if not vhd_last_modified:
             raise VMCreationDateError('No LastModified date found for instance {}'.format(vm_name))
-        create_time = datetime.strptime(str(vhd_last_modified), '%Y-%m-%dT%H:%M:%S %p')
-        self.logger.info("VM last edit time based on vhd =  {}".format(str(create_time)))
-        return create_time.replace(tzinfo=pytz.UTC)
+        creation_time = datetime.strptime(str(vhd_last_modified), '%Y-%m-%dT%H:%M:%S %p')
+        self.logger.info("VM last edit time based on vhd =  {}".format(creation_time))
+        return creation_time.astimezone(pytz.UTC)
 
     def create_netsec_group(self, group_name, resource_group):
         self.logger.info("Attempting to Create New Azure Security Group {}".format(group_name))

--- a/wrapanapi/exceptions.py
+++ b/wrapanapi/exceptions.py
@@ -81,3 +81,8 @@ class HostNotRemoved(Exception):
 
 class VMError(Exception):
     """Raised when a VM goes to the ERROR state."""
+
+
+class VMCreationDateError(Exception):
+    """Raised when we cannot determine a creation date for a VM"""
+    pass

--- a/wrapanapi/google.py
+++ b/wrapanapi/google.py
@@ -3,21 +3,23 @@
 
 Used to communicate with providers without using CFME facilities
 """
-
+import os
+import random
+import time
 from apiclient.discovery import build
 from apiclient.http import MediaFileUpload
 from apiclient import errors
+from json import dumps as json_dumps
+
+import httplib2
+import iso8601
+import tzlocal
+from oauth2client.service_account import ServiceAccountCredentials
+from wait_for import wait_for
+
 from base import WrapanapiAPIBase, VMInfo
 from exceptions import VMInstanceNotFound, ImageNotFoundError, ActionNotSupported, \
     ForwardingRuleNotFound
-from json import dumps as json_dumps
-from oauth2client.service_account import ServiceAccountCredentials
-from wait_for import wait_for
-import os
-import httplib2
-import iso8601
-import random
-import time
 
 # Retry transport and file IO errors.
 RETRYABLE_ERRORS = (httplib2.HttpLib2Error, IOError)
@@ -540,8 +542,8 @@ class GoogleCloudSystem(WrapanapiAPIBase):
     def vm_creation_time(self, instance_name):
         instance = self._find_instance_by_name(instance_name)
         vm_time_stamp = instance['creationTimestamp']
-        creation_time = (iso8601.parse_date(vm_time_stamp)).replace(tzinfo=None)
-        return creation_time
+        creation_time = (iso8601.parse_date(vm_time_stamp))
+        return tzlocal.get_localzone().fromutc(creation_time).replace(tzinfo=None)
 
     def vm_type(self, instance_name):
         instance = self._find_instance_by_name(instance_name)

--- a/wrapanapi/google.py
+++ b/wrapanapi/google.py
@@ -13,7 +13,7 @@ from json import dumps as json_dumps
 
 import httplib2
 import iso8601
-import tzlocal
+import pytz
 from oauth2client.service_account import ServiceAccountCredentials
 from wait_for import wait_for
 
@@ -543,7 +543,7 @@ class GoogleCloudSystem(WrapanapiAPIBase):
         instance = self._find_instance_by_name(instance_name)
         vm_time_stamp = instance['creationTimestamp']
         creation_time = (iso8601.parse_date(vm_time_stamp))
-        return tzlocal.get_localzone().fromutc(creation_time).replace(tzinfo=None)
+        return creation_time.replace(tzinfo=pytz.UTC)
 
     def vm_type(self, instance_name):
         instance = self._find_instance_by_name(instance_name)

--- a/wrapanapi/google.py
+++ b/wrapanapi/google.py
@@ -543,7 +543,7 @@ class GoogleCloudSystem(WrapanapiAPIBase):
         instance = self._find_instance_by_name(instance_name)
         vm_time_stamp = instance['creationTimestamp']
         creation_time = (iso8601.parse_date(vm_time_stamp))
-        return creation_time.replace(tzinfo=pytz.UTC)
+        return creation_time.astimezone(pytz.UTC)
 
     def vm_type(self, instance_name):
         instance = self._find_instance_by_name(instance_name)

--- a/wrapanapi/openstack.py
+++ b/wrapanapi/openstack.py
@@ -371,9 +371,9 @@ class OpenstackSystem(WrapanapiAPIBase):
     def vm_creation_time(self, vm_name):
         instance = self._find_instance_by_name(vm_name)
         # Example vm.created: 2014-08-14T23:29:30Z
-        create_time = datetime.strptime(instance.created, '%Y-%m-%dT%H:%M:%SZ')
+        creation_time = datetime.strptime(instance.created, '%Y-%m-%dT%H:%M:%SZ')
         # create time is UTC, localize it, strip tzinfo
-        return create_time.replace(tzinfo=pytz.UTC)
+        return creation_time.astimezone(pytz.UTC)
 
     def is_vm_running(self, vm_name):
         return self.vm_status(vm_name) in self.states['running']

--- a/wrapanapi/openstack.py
+++ b/wrapanapi/openstack.py
@@ -7,6 +7,9 @@ from contextlib import contextmanager
 from datetime import datetime
 from functools import partial
 
+import json
+import time
+import pytz
 from cinderclient.v2 import client as cinderclient
 from cinderclient import exceptions as cinder_exceptions
 from heatclient import client as heat_client
@@ -17,9 +20,6 @@ from novaclient.client import HTTPClient
 from novaclient.v2.floating_ips import FloatingIP
 from novaclient.v2.servers import Server
 from requests.exceptions import Timeout
-import json
-import time
-import tzlocal
 from wait_for import wait_for
 
 from base import WrapanapiAPIBase, VMInfo
@@ -373,7 +373,7 @@ class OpenstackSystem(WrapanapiAPIBase):
         # Example vm.created: 2014-08-14T23:29:30Z
         create_time = datetime.strptime(instance.created, '%Y-%m-%dT%H:%M:%SZ')
         # create time is UTC, localize it, strip tzinfo
-        return tzlocal.get_localzone().fromutc(create_time).replace(tzinfo=None)
+        return create_time.replace(tzinfo=pytz.UTC)
 
     def is_vm_running(self, vm_name):
         return self.vm_status(vm_name) in self.states['running']

--- a/wrapanapi/rhevm.py
+++ b/wrapanapi/rhevm.py
@@ -4,6 +4,7 @@
 Used to communicate with providers without using CFME facilities
 """
 import fauxfactory
+import pytz
 from ovirtsdk.api import API
 from ovirtsdk.infrastructure.errors import DisconnectedError, RequestError
 from ovirtsdk.xml import params
@@ -341,7 +342,7 @@ class RHEVMSystem(WrapanapiAPIBase):
 
     def vm_creation_time(self, vm_name):
         vm = self._get_vm(vm_name)
-        return vm.get_creation_time().replace(tzinfo=None)
+        return vm.get_creation_time().replace(tzinfo=pytz.UTC)
 
     def in_steady_state(self, vm_name):
         return self.vm_status(vm_name) in {"up", "down", "suspended"}

--- a/wrapanapi/rhevm.py
+++ b/wrapanapi/rhevm.py
@@ -342,7 +342,7 @@ class RHEVMSystem(WrapanapiAPIBase):
 
     def vm_creation_time(self, vm_name):
         vm = self._get_vm(vm_name)
-        return vm.get_creation_time().replace(tzinfo=pytz.UTC)
+        return vm.get_creation_time().astimezone(pytz.UTC)
 
     def in_steady_state(self, vm_name):
         return self.vm_status(vm_name) in {"up", "down", "suspended"}

--- a/wrapanapi/scvmm.py
+++ b/wrapanapi/scvmm.py
@@ -8,9 +8,11 @@ import winrm
 from cStringIO import StringIO
 from contextlib import contextmanager
 from datetime import datetime
+
 from lxml import etree
 from textwrap import dedent
 from wait_for import wait_for
+import tzlocal
 
 from base import WrapanapiAPIBase, VMInfo
 
@@ -214,9 +216,10 @@ class SCVMMSystem(WrapanapiAPIBase):
         xml = self.run_script(
             "Get-SCVirtualMachine -Name \"{}\""
             " -VMMServer $scvmm_server | ConvertTo-Xml -as String".format(vm_name))
-        date_time = etree.parse(StringIO(xml)).getroot().xpath(
+        xml_time = etree.parse(StringIO(xml)).getroot().xpath(
             "./Object/Property[@Name='CreationTime']/text()")[0]
-        return datetime.strptime(date_time, "%m/%d/%Y %I:%M:%S %p")
+        creation_time = datetime.strptime(xml_time, "%m/%d/%Y %I:%M:%S %p")
+        return tzlocal.get_localzone().fromutc(creation_time).replace(tzinfo=None)
 
     def info(self, vm_name):
         pass

--- a/wrapanapi/scvmm.py
+++ b/wrapanapi/scvmm.py
@@ -219,7 +219,7 @@ class SCVMMSystem(WrapanapiAPIBase):
         xml_time = etree.parse(StringIO(xml)).getroot().xpath(
             "./Object/Property[@Name='CreationTime']/text()")[0]
         creation_time = datetime.strptime(xml_time, "%m/%d/%Y %I:%M:%S %p")
-        return creation_time.replace(tzinfo=pytz.UTC)
+        return creation_time.astimezone(pytz.UTC)
 
     def info(self, vm_name):
         pass

--- a/wrapanapi/scvmm.py
+++ b/wrapanapi/scvmm.py
@@ -9,10 +9,10 @@ from cStringIO import StringIO
 from contextlib import contextmanager
 from datetime import datetime
 
+import pytz
 from lxml import etree
 from textwrap import dedent
 from wait_for import wait_for
-import tzlocal
 
 from base import WrapanapiAPIBase, VMInfo
 
@@ -219,7 +219,7 @@ class SCVMMSystem(WrapanapiAPIBase):
         xml_time = etree.parse(StringIO(xml)).getroot().xpath(
             "./Object/Property[@Name='CreationTime']/text()")[0]
         creation_time = datetime.strptime(xml_time, "%m/%d/%Y %I:%M:%S %p")
-        return tzlocal.get_localzone().fromutc(creation_time).replace(tzinfo=None)
+        return creation_time.replace(tzinfo=pytz.UTC)
 
     def info(self, vm_name):
         pass

--- a/wrapanapi/virtualcenter.py
+++ b/wrapanapi/virtualcenter.py
@@ -224,7 +224,8 @@ class VMWareSystem(WrapanapiAPIBase):
         """
         Build a filter spec based on ``obj`` and return the updated object.
 
-        :param obj: The managed object to update
+        Args:
+             obj (pyVmomi.ManagedObject): The managed object to update, will be a specific subclass
         """
         # Set up the filter specs
         property_spec = vmodl.query.PropertyCollector.PropertySpec(type=type(obj), all=True)
@@ -246,9 +247,11 @@ class VMWareSystem(WrapanapiAPIBase):
     def _get_vm(self, vm_name, force=False):
         """Returns a vm from the VI object.
 
-        :param vm_name: The name of the VM
-        :param force: Ignore the cache when updating
-        :returns: a pyVmomi object.
+        Args:
+            vm_name (string): The name of the VM
+            force (bool): Ignore the cache when updating
+        Returns:
+             pyVmomi.vim.VirtualMachine: VM object
         """
         if vm_name not in self._vm_cache or force:
             vm = self._get_obj(vim.VirtualMachine, vm_name)
@@ -262,8 +265,11 @@ class VMWareSystem(WrapanapiAPIBase):
     def _get_resource_pool(self, resource_pool_name=None):
         """ Returns a resource pool managed object for a specified name.
 
-        :param resource_pool_name: The name of the resource pool. If None, first one will be picked.
-        :returns: The managed object of the resource pool.
+        Args:
+            resource_pool_name (string): The name of the resource pool. If None, first one will be
+        picked.
+        Returns:
+             pyVmomi.vim.ResourcePool: The managed object of the resource pool.
         """
         if resource_pool_name is not None:
             return self._get_obj(vim.ResourcePool, resource_pool_name)
@@ -277,8 +283,10 @@ class VMWareSystem(WrapanapiAPIBase):
         Update a task and check its state. If the task state is not ``queued``, ``running`` or
         ``None``, then return the state. Otherwise return None.
 
-        :param task: The task whose state is being monitored
-        :returns: Task state
+        Args:
+            task (pyVmomi.vim.Task): The task whose state is being monitored
+        Returns:
+            string: pyVmomi.vim.TaskInfo.state value if the task is not queued/running/None
         """
         task = self._get_updated_obj(task)
         if task.info.state not in ['queued', 'running', None]:
@@ -287,8 +295,10 @@ class VMWareSystem(WrapanapiAPIBase):
     def _task_status(self, task):
         """Update a task and return its state, as a vim.TaskInfo.State string wrapper
 
-        :param task: The task whose state is being returned
-        :returns: vim.TaskInfo.State string or None
+        Args:
+            task (pyVmomi.vim.Task): The task whose state is being returned
+        Returns:
+            string: pyVmomi.vim.TaskInfo.state value
         """
         task = self._get_updated_obj(task)
         return task.info.state

--- a/wrapanapi/virtualcenter.py
+++ b/wrapanapi/virtualcenter.py
@@ -13,12 +13,12 @@ except AttributeError:
 import operator
 import re
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from distutils.version import LooseVersion
 from functools import partial
 
 import six
-import tzlocal
+import pytz
 from wait_for import wait_for, TimedOutError
 from pyVmomi import vim, vmodl
 from pyVim.connect import SmartConnect, Disconnect
@@ -546,7 +546,7 @@ class VMWareSystem(WrapanapiAPIBase):
             if not creation_time:
                 raise VMCreationDateError('Could not find a creation date for {}'.format(vm_name))
         # localize and make tz-naive
-        return tzlocal.get_localzone().localize(creation_time).replace(tzinfo=None)
+        return creation_time.replace(tzinfo=pytz.UTC)
 
     def get_vm_host_name(self, vm_name):
         vm = self._get_vm(vm_name)

--- a/wrapanapi/virtualcenter.py
+++ b/wrapanapi/virtualcenter.py
@@ -476,8 +476,8 @@ class VMWareSystem(WrapanapiAPIBase):
         task = vm.Destroy_Task()
 
         try:
-            wait_for(lambda: self._task_status(task) == 'success', delay=1, num_sec=600)
-            return True
+            wait_for(lambda: self._task_status(task) == 'success', delay=3, num_sec=600)
+            return self._task_status(task) == 'success'
         except TimedOutError:
             return False
 


### PR DESCRIPTION
Complete re-write of virtualcenter.vm_creation_time, don't return the uptime as vm_creation_time.
Parse vm events for a deployment/creation event

Otherwise standardize other modules to return a localized datetime object for vm_creation_time.

Add in some exception raising for azure/scvmm where the winrm crap blows up unexpectedly and you end up with empty lists for dates, and obscure exceptions otherwise.

The other classes are actually using API's and fail reasonably when the queried value isn't available.

Organized the imports, which makes the diff a little messy. :dealwithit:


FIXES RHCFQE-3262