### PR TITLE
[RFR] Container Management Extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 boto
+cached_property
 enum34
 fauxfactory>=2.0.7
 google-api-python-client

--- a/wrapanapi/__init__.py
+++ b/wrapanapi/__init__.py
@@ -9,6 +9,6 @@ from scvmm import SCVMMSystem  # NOQA
 from azure import AzureSystem  # NOQA
 from virtualcenter import VMWareSystem  # NOQA
 from google import GoogleCloudSystem  # NOQA
-from kubernetes import Kubernetes  # NOQA
-from openshift import Openshift  # NOQA
+from wrapanapi.containers.providers.kubernetes import Kubernetes  # NOQA
+from wrapanapi.containers.providers.openshift import Openshift  # NOQA
 from hawkular import Hawkular  # NOQA

--- a/wrapanapi/containers/__init__.py
+++ b/wrapanapi/containers/__init__.py
@@ -1,0 +1,104 @@
+from cached_property import cached_property
+
+from wrapanapi.exceptions import RequestFailedException
+
+
+class ContainersResourceBase(object):
+    """
+    A container resource base class. This class includes the base functions of (almost)
+    all container resources. Each resource has its own API entry and use different API
+    (Kubernetes or OpenShift). Each resource has get, post, patch and delete methods which
+    directed to the path of the resource.
+    """
+    def __init__(self, provider, name, namespace):
+        self.provider = provider
+        self.name = name
+        self.namespace = namespace
+
+    def __eq__(self, other):
+        return (self.namespace == getattr(other, 'namespace', None) and
+                self.name == getattr(other, 'name', None))
+
+    def __repr__(self):
+        return '<{} name="{}" namespace="{}">'.format(
+            self.__class__.__name__, self.name, self.namespace)
+
+    def exists(self):
+        """Return whether this object exists or not."""
+        try:
+            self.get()
+            return True
+        except RequestFailedException:
+            return False
+
+    @cached_property
+    def api(self):
+        """The API to use - the default is Kubernetes but some resources use the OpenShift API"""
+        return self.provider.api
+
+    @property
+    def name_for_api(self):
+        """The name used for the API (In Image the name for API is id)"""
+        return self.name
+
+    @property
+    def project_name(self):
+        # For backward compatibility
+        return self.namespace
+
+    @property
+    def metadata(self):
+        return self.get()['metadata']
+
+    @property
+    def spec(self):
+        return self.get()['spec']
+
+    @property
+    def status(self):
+        return self.get()['status']
+
+    def get(self, convert=None):
+        """Sends a GET request to the resource."""
+        status_code, json_content = self.api.get(self.RESOURCE_TYPE, name=self.name_for_api,
+                                                 namespace=self.namespace, convert=convert)
+        if status_code != 200:
+            raise RequestFailedException('GET request of {} "{}" returned status code {}. '
+                                         'json content: {}'
+                                         .format(self.RESOURCE_TYPE, self.name_for_api,
+                                                 status_code, json_content))
+        return json_content
+
+    def post(self, data, convert=None):
+        """Sends a POST request with the given data to the resource."""
+        return self.api.post(self.RESOURCE_TYPE, data, name=self.name_for_api,
+                             namespace=self.namespace, convert=convert)
+
+    def patch(self, data, convert=None,
+              headers={'Content-Type': 'application/strategic-merge-patch+json'}):
+        """Sends a PATCH request with the given data/headers to the resource."""
+        return self.api.patch(self.RESOURCE_TYPE, data, name=self.name_for_api,
+                              namespace=self.namespace, convert=convert, headers=headers)
+
+    def delete(self, convert=None):
+        """Sends a DELETE request to the resource (delete the resource)."""
+        return self.api.delete(self.RESOURCE_TYPE, self.name_for_api,
+                               namespace=self.namespace, convert=convert)
+
+    def list_labels(self):
+        """List the labels of this resource"""
+        return self.metadata.get('labels', {})
+
+    def set_label(self, key, value):
+        """Sets a label for this resource"""
+        return self.patch({'metadata': {'labels': {key: str(value)}}})
+
+    def delete_label(self, key):
+        """Deletes a label from this resource"""
+        labels = self.list_labels()
+        if key not in labels:
+            raise Exception('{} has no label "{}"'.format(self, key))
+        del labels[key]
+        labels = {'$patch': 'replace'}
+        labels.update(labels)
+        return self.patch({'metadata': {'labels': labels}})

--- a/wrapanapi/containers/container.py
+++ b/wrapanapi/containers/container.py
@@ -1,0 +1,21 @@
+from pod import Pod
+
+
+class Container(object):
+
+    def __init__(self, provider, name, pod, image):
+        if not isinstance(pod, Pod):
+            raise TypeError('pod argument should be an Pod instance')
+        self.provider = provider
+        self.name = name
+        self.pod = pod
+        self.image = image
+
+    @property
+    def cg_name(self):
+        # For backward compatibility
+        return self.pod.name
+
+    @property
+    def namespace(self):
+        return self.pod.namespace

--- a/wrapanapi/containers/deployment_config.py
+++ b/wrapanapi/containers/deployment_config.py
@@ -1,0 +1,15 @@
+from cached_property import cached_property
+from wrapanapi.containers import ContainersResourceBase
+
+
+class DeploymentConfig(ContainersResourceBase):
+    RESOURCE_TYPE = 'deploymentconfig'
+
+    def __init__(self, provider, name, namespace, template_data, replicas):
+        ContainersResourceBase.__init__(self, provider, name, namespace)
+        self.template_data = template_data
+        self.replicas = replicas
+
+    @cached_property
+    def api(self):
+        return self.provider.o_api

--- a/wrapanapi/containers/image.py
+++ b/wrapanapi/containers/image.py
@@ -1,0 +1,57 @@
+from cached_property import cached_property
+
+from wrapanapi.containers import ContainersResourceBase
+
+
+class Image(ContainersResourceBase):
+    RESOURCE_TYPE = 'image'
+
+    def __init__(self, provider, name, image_id):
+        ContainersResourceBase.__init__(self, provider, name, None)
+        self.id = image_id
+
+    def __eq__(self, other):
+        return self.id == getattr(other, 'id', None)
+
+    def __repr__(self):
+        return '<{} name="{}" id="{}">'.format(
+            self.__class__.__name__, self.name, self.id)
+
+    @staticmethod
+    def parse_docker_image_info(image_str):
+        """Splits full image name into registry, name, id and tag
+
+        Registry and tag are optional, name and id are always present.
+
+        Example:
+            <registry>/jboss-fuse-6/fis-karaf-openshift:<tag>@sha256:<sha256> =>
+            <registry>, jboss-fuse-6/fis-karaf-openshift, sha256:<sha256>, <tag>
+        """
+        registry, image_str = image_str.split('/', 1) if '/' in image_str else ('', image_str)
+        name, image_id = image_str.split('@')
+        tag = name.split(':') if ':' in image_str else (image_str, '')
+        return registry, name, image_id, tag
+
+    @cached_property
+    def docker_image_reference(self):
+        return self.get().get('dockerImageReference', '')
+
+    @cached_property
+    def docker_image_info(self):
+        return self.parse_docker_image_info(self.docker_image_reference)
+
+    @property
+    def name_for_api(self):
+        return self.id
+
+    @cached_property
+    def api(self):
+        return self.provider.o_api
+
+    @cached_property
+    def registry(self):
+        return self.docker_image_info[0]
+
+    @cached_property
+    def tag(self):
+        return self.docker_image_info[3]

--- a/wrapanapi/containers/image_registry.py
+++ b/wrapanapi/containers/image_registry.py
@@ -1,0 +1,20 @@
+from cached_property import cached_property
+from wrapanapi.containers import ContainersResourceBase
+
+
+class ImageRegistry(ContainersResourceBase):
+    RESOURCE_TYPE = 'imagestream'
+
+    def __init__(self, provider, name, registry, namespace):
+        ContainersResourceBase.__init__(self, provider, name, namespace)
+        self.registry = registry
+        full_host = registry.split('/')[0]
+        self.host, self.port = full_host.split(':') if ':' in full_host else (full_host, '')
+
+    def __repr__(self):
+        return '<{} name="{}" host="{}" namespace="{}">'.format(
+            self.__class__.__name__, self.name, self.host, self.namespace)
+
+    @cached_property
+    def api(self):
+        return self.provider.o_api

--- a/wrapanapi/containers/node.py
+++ b/wrapanapi/containers/node.py
@@ -1,0 +1,21 @@
+from wrapanapi.containers import ContainersResourceBase
+
+
+class Node(ContainersResourceBase):
+    RESOURCE_TYPE = 'node'
+
+    def __init__(self, provider, name):
+        ContainersResourceBase.__init__(self, provider, name, None)
+
+    @property
+    def cpu(self):
+        return int(self.status['capacity']['cpu'])
+
+    @property
+    def ready(self):
+        return self.status['conditions'][0]['status']
+
+    @property
+    def memory(self):
+        return int(round(int(
+            self.status['capacity']['memory'][:-2]) * 0.00000102400))  # KiB to GB

--- a/wrapanapi/containers/pod.py
+++ b/wrapanapi/containers/pod.py
@@ -1,0 +1,13 @@
+from wrapanapi.containers import ContainersResourceBase
+
+
+class Pod(ContainersResourceBase):
+    RESOURCE_TYPE = 'pod'
+
+    @property
+    def restart_policy(self):
+        return self.spec['restartPolicy']
+
+    @property
+    def dns_policy(self):
+        return self.spec['dnsPolicy']

--- a/wrapanapi/containers/project.py
+++ b/wrapanapi/containers/project.py
@@ -1,0 +1,18 @@
+from wrapanapi.containers import ContainersResourceBase
+
+
+class Project(ContainersResourceBase):
+    RESOURCE_TYPE = 'namespace'
+
+    def __init__(self, provider, name):
+        ContainersResourceBase.__init__(self, provider, name, None)
+
+    def create(self):
+        status_code, json_content = self.provider.api.post(
+            'namespace',
+            {"apiVersion": "v1", "kind": "Project", "metadata": {"name": self.name}}
+        )
+        if status_code not in (200, 201):
+            raise Exception('Failed to create project "{}". status_code: {}; json_content: {};'
+                            .format(self.name, status_code, json_content))
+        return status_code, json_content

--- a/wrapanapi/containers/replicator.py
+++ b/wrapanapi/containers/replicator.py
@@ -1,0 +1,13 @@
+from wrapanapi.containers import ContainersResourceBase
+
+
+class Replicator(ContainersResourceBase):
+    RESOURCE_TYPE = 'replicationcontroller'
+
+    @property
+    def replicas(self):
+        return self.spec['replicas']
+
+    @property
+    def current_replicas(self):
+        return self.status['replicas']

--- a/wrapanapi/containers/route.py
+++ b/wrapanapi/containers/route.py
@@ -1,0 +1,11 @@
+from cached_property import cached_property
+
+from wrapanapi.containers import ContainersResourceBase
+
+
+class Route(ContainersResourceBase):
+    RESOURCE_TYPE = 'route'
+
+    @cached_property
+    def api(self):
+        return self.provider.o_api

--- a/wrapanapi/containers/service.py
+++ b/wrapanapi/containers/service.py
@@ -1,0 +1,13 @@
+from wrapanapi.containers import ContainersResourceBase
+
+
+class Service(ContainersResourceBase):
+    RESOURCE_TYPE = 'service'
+
+    @property
+    def portal_ip(self):
+        return self.spec['clusterIP']
+
+    @property
+    def session_affinity(self):
+        return self.spec['sessionAffinity']

--- a/wrapanapi/containers/template.py
+++ b/wrapanapi/containers/template.py
@@ -1,0 +1,11 @@
+from cached_property import cached_property
+
+from wrapanapi.containers import ContainersResourceBase
+
+
+class Template(ContainersResourceBase):
+    RESOURCE_TYPE = 'template'
+
+    @cached_property
+    def api(self):
+        return self.provider.o_api

--- a/wrapanapi/containers/volume.py
+++ b/wrapanapi/containers/volume.py
@@ -1,0 +1,20 @@
+from wrapanapi.containers import ContainersResourceBase
+
+
+class Volume(ContainersResourceBase):
+    RESOURCE_TYPE = 'persistentvolume'
+
+    def __init__(self, provider, name):
+        ContainersResourceBase.__init__(self, provider, name, None)
+
+    def __repr__(self):
+        return '<{} name="{}" capacity="{}">'.format(
+            self.__class__.__name__, self.name, self.capacity)
+
+    @property
+    def capacity(self):
+        return self.spec['capacity']['storage']
+
+    @property
+    def accessmodes(self):
+        self.spec['accessModes']

--- a/wrapanapi/exceptions.py
+++ b/wrapanapi/exceptions.py
@@ -37,6 +37,11 @@ class RestClientException(Exception):
     pass
 
 
+class RequestFailedException(Exception):
+    """Raised if some request returned unexpected status code"""
+    pass
+
+
 class NetworkNameNotFound(Exception):
     pass
 


### PR DESCRIPTION
Extend containers providers functionality.

- Created package wrapanapi.containers which includes openshift, kuberenetes and containers resources.
- Each container resource inherit wrapanapi.containers.ContainersResourceBase which provide the functionality to access the object API (GET/POST/PATCH/DELETE functions), the purpose is to provide mgmt entry for each container [object in integration_tests](https://github.com/ManageIQ/integration_tests/tree/master/cfme/containers).
- Added tests/test_openshift.py which tests all the required components.
- This commit is the start point for many other functionalities that required for containers provider REST-API which will take place later.