### PR TITLE
[RFR] Update openstack.vm_creation_time

### DIFF
--- a/wrapanapi/openstack.py
+++ b/wrapanapi/openstack.py
@@ -373,7 +373,7 @@ class OpenstackSystem(WrapanapiAPIBase):
         # Example vm.created: 2014-08-14T23:29:30Z
         creation_time = datetime.strptime(instance.created, '%Y-%m-%dT%H:%M:%SZ')
         # create time is UTC, localize it, strip tzinfo
-        return creation_time.astimezone(pytz.UTC)
+        return creation_time.replace(tzinfo=pytz.UTC)
 
     def is_vm_running(self, vm_name):
         return self.vm_status(vm_name) in self.states['running']


### PR DESCRIPTION
creation_time is tznaive since python doesn't parse single Z as a
timezone.

timezone string includes 'Z', so we know its UTC if it was matched, make
the return datetime object tzaware by using replace() instead of
astimezone - which required a tzaware object in the first place.

Tested against CFME QE's 'rhos7-ga' provider.  Potential for more updates as we adopt more recent openstack environments.