### PR TITLE
[RFR] Update rhevm api kwargs, <4.0 vs >4.0

### DIFF
--- a/wrapanapi/rhevm.py
+++ b/wrapanapi/rhevm.py
@@ -96,8 +96,8 @@ class RHEVMSystem(WrapanapiAPIBase):
     def __init__(self, hostname, username, password, **kwargs):
         # generate URL from hostname
         super(RHEVMSystem, self).__init__(kwargs)
-        rhv_gt_4 = float(kwargs['version']) >= 4.0
-        url_component = 'ovirt-engine/api' if rhv_gt_4 else 'api'
+        less_than_rhv_4 = float(kwargs['version']) < 4.0
+        url_component = 'api' if less_than_rhv_4 else 'ovirt-engine/api'
         if 'api_endpoint' in kwargs:
             url = kwargs['api_endpoint']
         elif 'port' in kwargs:
@@ -111,7 +111,7 @@ class RHEVMSystem(WrapanapiAPIBase):
             'username': username,
             'password': password,
             'insecure': True,
-            'filter': False if rhv_gt_4 else True}
+            'filter': True if less_than_rhv_4 else False}
         self.kwargs = kwargs
 
     @property

--- a/wrapanapi/rhevm.py
+++ b/wrapanapi/rhevm.py
@@ -96,7 +96,8 @@ class RHEVMSystem(WrapanapiAPIBase):
     def __init__(self, hostname, username, password, **kwargs):
         # generate URL from hostname
         super(RHEVMSystem, self).__init__(kwargs)
-        url_component = 'ovirt-engine/api' if float(kwargs['version']) >= 4.0 else 'api'
+        rhv_gt_4 = float(kwargs['version']) >= 4.0
+        url_component = 'ovirt-engine/api' if rhv_gt_4 else 'api'
         if 'api_endpoint' in kwargs:
             url = kwargs['api_endpoint']
         elif 'port' in kwargs:
@@ -109,9 +110,8 @@ class RHEVMSystem(WrapanapiAPIBase):
             'url': url,
             'username': username,
             'password': password,
-            'filter': True,
-            'insecure': True
-        }
+            'insecure': True,
+            'filter': False if rhv_gt_4 else True}
         self.kwargs = kwargs
 
     @property


### PR DESCRIPTION
API requests against rhv41 provider were resulting in empty results (`list_vm`) because of the filter kwarg setting.

At some point we'll need to migrate the entire module to ovirt-engine-sdk-python 4.1.6+, but not yet.