### PR TITLE
[RFR] Update google.all_vms, add by_zone option

### DIFF
--- a/wrapanapi/base.py
+++ b/wrapanapi/base.py
@@ -358,7 +358,7 @@ class WrapanapiAPIBaseVM(WrapanapiAPIBase):
             'Provider {} does not implement get_meta_value'.format(type(self).__name__))
 
     def get_vm_guid(self, vm_name):
-        for vm in self.all_vms():
+        for vm in self.list_vm():
             if vm.name == vm_name:
                 return vm.uuid
         else:


### PR DESCRIPTION
Support filtering by object's zone in all_vms, pass by_zone=True in
list_vm method

This means list_vm will now only list the VMs that are in the object's
zone. It should have been doing this all along, but has been returning
an unfiltered list of all instances in all regions

FIXES #195 

Tested both `list_vm()` and `all_vms()` against gce_central provider config from CFME QE. This was a GCE provider with zone of asia-east1-a. Was able to cleanly filter or get all VMs in the account.


Also modified `base.get_vm_guid` to call list_vm instead of all_vms