### PR TITLE
[RFR] Update azure properties, use cached_property

### DIFF
--- a/wrapanapi/msazure.py
+++ b/wrapanapi/msazure.py
@@ -296,7 +296,7 @@ class AzureSystem(WrapanapiAPIBaseVM):
         return current_ip_address
 
     def list_subscriptions(self):
-        return [(s.display_name, s.subscription_id) for s in
+        return [(str(s.display_name), str(s.subscription_id)) for s in
                 self.subscription_client.subscriptions.list() if
                 s.state == SubscriptionState.enabled]
 


### PR DESCRIPTION
Don't create the client objects in `__init__`

This allows for changing attributes after the object is created.

Related to #204 where @lkhomenk  is enhancing azure cleanup.

This change will allow for easier instantiation and modification of the AzureSystem object within the context of cleanup and generation of the AzureSystem object from YAML definitions of providers.

If I have a provider, but don't yet have subscription IDs, with this design I can create an AzureSystem object, query the subscription ID's available, and then set one.