### PR TITLE
[RFR] Fix list_services and list_container_groups

### DIFF
--- a/wrapanapi/containers/providers/rhkubernetes.py
+++ b/wrapanapi/containers/providers/rhkubernetes.py
@@ -102,11 +102,9 @@ class Kubernetes(WrapanapiAPIBase):
         for entity_j in entities_j:
             meta = entity_j['metadata']
             entity = Pod(self, meta['name'], meta['namespace'])
-            if project_name:
-                meta = entity_j['metadata']
-                if project_name and project_name != meta['namespace']:
-                    continue
-                entities.append(Pod(self, meta['name'], meta['namespace']))
+            if project_name and project_name != meta['namespace']:
+                continue
+            entities.append(Pod(self, meta['name'], meta['namespace']))
         return entities
 
     def list_service(self, project_name=None):
@@ -117,11 +115,9 @@ class Kubernetes(WrapanapiAPIBase):
         for entity_j in entities_j:
             meta = entity_j['metadata']
             entity = Service(self, meta['name'], meta['namespace'])
-            if project_name:
-                meta = entity_j['metadata']
-                if project_name and project_name != meta['namespace']:
-                    continue
-                entities.append(Service(self, meta['name'], meta['namespace']))
+            if project_name and project_name != meta['namespace']:
+                continue
+            entities.append(Service(self, meta['name'], meta['namespace']))
         return entities
 
     def list_replication_controller(self):


### PR DESCRIPTION
Fixes for the list_container_groups and list_service methods for CMQE. 

Manual testing:
```
In [2]: mgmt = juwatts.mgmt

In [3]: mgmt
Out[3]: <wrapanapi.containers.providers.openshift.Openshift at 0x7f8a415e6ed0>
In [8]: pods = mgmt.list_container_group()

In [9]: pods
Out[9]: 
[<Pod name="docker-registry-1-gjjgs" namespace="default">,
 <Pod name="nationalparks-katacoda-1-build" namespace="default">,
 <Pod name="nationalparks-katacoda-2-build" namespace="default">,
 <Pod name="registry-console-1-xmrr5" namespace="default">,
 <Pod name="router-2-lk4nd" namespace="default">,
 <Pod name="router-2-nwdg9" namespace="default">,
 <Pod name="logging-curator-1-jk429" namespace="logging">,
 <Pod name="logging-es-data-master-z2yths8j-1-d6bf5" namespace="logging">,
 <Pod name="logging-fluentd-2q9jm" namespace="logging">,
 <Pod name="logging-fluentd-lcgl4" namespace="logging">,
 <Pod name="logging-fluentd-nll8j" namespace="logging">,
 <Pod name="logging-fluentd-w5tq4" namespace="logging">,
 <Pod name="logging-kibana-1-93hxv" namespace="logging">,
 <Pod name="hawkular-cassandra-1-fkb4r" namespace="openshift-infra">,
 <Pod name="hawkular-metrics-f5czf" namespace="openshift-infra">,
 <Pod name="heapster-rknxh" namespace="openshift-infra">,
 <Pod name="nationalparks-katacoda-1-build" namespace="park-maps">,
 <Pod name="nationalparks-katacoda-1-f9z46" namespace="park-maps">,
 <Pod name="nationalparks-katacoda-1-gtg8f" namespace="park-maps">,
 <Pod name="parksmap-katacoda-1-q07h2" namespace="park-maps">]

In [10]: pods = mgmt.list_container_group(project_name = 'default')

In [11]: pods
Out[11]: 
[<Pod name="docker-registry-1-gjjgs" namespace="default">,
 <Pod name="nationalparks-katacoda-1-build" namespace="default">,
 <Pod name="nationalparks-katacoda-2-build" namespace="default">,
 <Pod name="registry-console-1-xmrr5" namespace="default">,
 <Pod name="router-2-lk4nd" namespace="default">,
 <Pod name="router-2-nwdg9" namespace="default">]

In [12]: 

In [12]: services = mgmt.list_service()

In [13]: services
Out[13]: 
[<Service name="docker-registry" namespace="default">,
 <Service name="kubernetes" namespace="default">,
 <Service name="nationalparks-katacoda" namespace="default">,
 <Service name="parksmap-katacoda" namespace="default">,
 <Service name="registry-console" namespace="default">,
 <Service name="router" namespace="default">,
 <Service name="logging-es" namespace="logging">,
 <Service name="logging-es-cluster" namespace="logging">,
 <Service name="logging-kibana" namespace="logging">,
 <Service name="hawkular-cassandra" namespace="openshift-infra">,
 <Service name="hawkular-cassandra-nodes" namespace="openshift-infra">,
 <Service name="hawkular-metrics" namespace="openshift-infra">,
 <Service name="heapster" namespace="openshift-infra">,
 <Service name="nationalparks-katacoda" namespace="park-maps">,
 <Service name="parksmap-katacoda" namespace="park-maps">]

In [14]: services = mgmt.list_service(project_name = 'logging')

In [15]: services
Out[15]: 
[<Service name="logging-es" namespace="logging">,
 <Service name="logging-es-cluster" namespace="logging">,
 <Service name="logging-kibana" namespace="logging">]

In [16]: 


```