### PR TITLE
[RFR]few fixes for list_vm / list_templates

### DIFF
--- a/wrapanapi/msazure.py
+++ b/wrapanapi/msazure.py
@@ -155,7 +155,7 @@ class AzureSystem(WrapanapiAPIBaseVM):
         vm_list = []
         for res_group in self.list_resource_groups():
             vms = self.vms_collection.list(resource_group_name=res_group)
-            vm_list += [vm.name for vm in vms if vm.location == self.region]
+            vm_list.extend([vm.name for vm in vms if vm.location == self.region])
         return vm_list
 
     def list_vm_by_resource_group(self, resource_group=None):


### PR DESCRIPTION
This fixes test_provider_crud for azure
`_stats_available` was  getting from info:
`num_vms` - we got from all Regions
`num_templates` - we got all vhds from container that is not used by CFME templates + we were skipping Private Images

Needs - MR 450