### PR TITLE
Update azure version to >=3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,8 @@ websocket_client
 dateparser
 boto3
 packaging
-azure>=2.0.0
+azure>=3.0.0
+azure-storage-common>=1.0
 pyvcloud
 ###
 # Libraries with compiled components, and their related devel packages


### PR DESCRIPTION
Force update of azure-storage-common >=1.1.0

Pip is installing azure 3.0, which needs azure-storage-common 1.1.0. The azure-storage-common 0.37.1 package was satisfying azure >=2.0, and being installed from cache.

This forces install of azure 3.0 dependent packages.