### PR TITLE
[RFR] openshift client version freeze

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ fauxfactory>=2.0.7
 google-api-python-client
 inflection
 ovirt-engine-sdk-python<4.0.0
-openshift
+openshift==0.3.4
 pyvmomi>=6.5.0.2017.5.post1
 python-cinderclient
 python-ironicclient


### PR DESCRIPTION
It turned out that newest version (0.4.3) is incompatible. So, I add a version freeze for a while.