### PR TITLE
Boto3 for cloudformation stacks 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,8 @@ tzlocal
 wait_for
 websocket_client
 dateparser
-boto3
+boto3==1.6.6
+botocore==1.9.6
 packaging
 azure>=3.0.0
 azure-storage-common>=1.0


### PR DESCRIPTION
We need retries implemented to be able to handle rate exceeded from aws.
In this PR I reworked delete_stack from boto2 to boto3
PR(https://github.com/ManageIQ/integration_tests/pull/6850) relies on this PR.
Tested.