### PR TITLE
Update pyvcloud requirement, freeze 19.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ boto3
 packaging
 azure>=3.0.0
 azure-storage-common>=1.0
-pyvcloud
+pyvcloud==19.1.2
 
 # suds jurko supports python3, suds is only used on python2
 suds-jurko; python_version > '3.0'


### PR DESCRIPTION
19.2.0 imports urllib.parse, py3 requirement.