### PR TITLE
[1LP][RFR] Don't strip image path

### DIFF
--- a/wrapanapi/msazure.py
+++ b/wrapanapi/msazure.py
@@ -482,7 +482,7 @@ class AzureSystem(WrapanapiAPIBaseVM):
         # todo: weird method to refactor it later
         container_client = BlockBlobService(storage_account, self.storage_key)
         src_uri = container_client.make_blob_url(container_name=template_container,
-                                                 blob_name=template.split("/")[-1])
+                                                 blob_name=template)
         operation = container_client.copy_blob(container_name=storage_container,
                                                blob_name=vm_name + ".vhd",
                                                copy_source=src_uri)


### PR DESCRIPTION
The full path for provisioning templates was not being utilized. This changes it so we don't strip the full path name when it is defined. This makes it easier to take the full image path after provisioning tools like packer build the image and put it straight into the YAMLs.

So a config like this would work now:
```yaml
        templates:
            small_template:
                name: 'Microsoft.Compute/Images/fedora-tmpl-sm.vhd'
                creds: cloudqe_azure_instance
            big_template:
                name: 'Microsoft.Compute/Images/tmpl-osDisk.vhd'
                creds: cloudqe_azure_instance
```

There should be no impact with this change to azure tests on the current setup because the small template name's file path is currently defined as 'fedora-tmpl-sm.vhd' and that is also where it lives in the cloud blob storage. 