### PR TITLE
[RFR] Handle empty response in Nuage API calls

### DIFF
--- a/wrapanapi/nuage.py
+++ b/wrapanapi/nuage.py
@@ -78,4 +78,4 @@ class NuageSystem(WrapanapiAPIBase):
             data=json.dumps(data) if data else None
         )
         response.raise_for_status()
-        return response.json()
+        return response.json() if response.text else []


### PR DESCRIPTION
With this commit we prevent JSON parsing in case of empty response body, because it fails otherwise. We now return empty list in such cases.