### PR TITLE
[1LP][RFR] Reimplement list_servers and fix get_server_memory in lenovo.py

### DIFF
--- a/wrapanapi/lenovo.py
+++ b/wrapanapi/lenovo.py
@@ -86,8 +86,6 @@ class LenovoSystem(WrapanapiAPIBase):
         return response['appliance']['version']
 
     def list_servers(self):
-        cabinet_nodes = []
-        chassis_nodes = []
         inventory = []
 
         # Collect the nodes associated with a cabinet or chassis


### PR DESCRIPTION
This PR updates the _list_servers_ method to gather a list of nodes/servers from all cabinets instead of just the first cabinet. Also, the _get_server_memory_ method was updated to return the amount of memory in bytes, so it matches the value that is displayed in the UI.