### PR TITLE
[RFR] 2 min sometimes isn't enough to delete vm

### DIFF
--- a/wrapanapi/containers/providers/rhopenshift.py
+++ b/wrapanapi/containers/providers/rhopenshift.py
@@ -942,7 +942,7 @@ class Openshift(Kubernetes):
                                                            metadata=role_binding_name)
         auth_api.create_namespaced_role_binding(namespace=namespace, body=puller_role_binding)
 
-    def delete_project(self, name, wait=120):
+    def delete_project(self, name, wait=300):
         """Removes project(namespace) and all entities in it.
 
         Args:


### PR DESCRIPTION
Some jenkins template tester jobs fail on destroy vm step though vm is deleted. It seems 2 min sometimes isn't enough. I increased value to 5 min