### PR TITLE
[RFR] Update containers rhopenshift list_image_id to return unique list of image ids

### DIFF
--- a/wrapanapi/systems/container/rhopenshift.py
+++ b/wrapanapi/systems/container/rhopenshift.py
@@ -248,13 +248,13 @@ class Openshift(System):
         return [pod.spec.containers for pod in pods]
 
     def list_image_id(self, namespace=None):
-        """Returns list of image ids (derived from pods)"""
+        """Returns list of unique image ids (derived from pods)"""
         pods = self.list_pods(namespace=namespace)
         statuses = []
         for pod in pods:
             for status in pod.status.container_statuses:
                 statuses.append(status)
-        return [status.image_id for status in statuses]
+        return sorted(set([status.image_id for status in statuses]))
 
     def list_image_registry(self, namespace=None):
         """Returns list of image registries (derived from pods)"""


### PR DESCRIPTION
Update method list_image_id to return a list of unique image ids.

No PRT test.
Will be implemented as part of new PR [Update Container test project dashboard according to wrapanapi changes #7400](https://github.com/ManageIQ/integration_tests/pull/7400)
Manual Testing:
My test provider has 6 images on namespace\project 'test-project-dashboard',
But only 4 unique images.
example before wrapanapi change, get list with 6 images, same images are on bold:
ocp_37_prom.mgmt.list_image_id(namespace='test-project-dashboard')
Out[1]: 
[**'docker-pullable://registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat7-openshift@sha256:81daf7f932be28e8b3d948d86ce6f175a98124ba54dbb40c3609317353f93753'**,
 **'docker-pullable://registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat7-openshift@sha256:81daf7f932be28e8b3d948d86ce6f175a98124ba54dbb40c3609317353f93753'**,
 **'docker-pullable://registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat8-openshift@sha256:e9388df6c16dd0bdfe09b11250598392e590c4a49e9720925644e3f22ed49b56'**,
 **'docker-pullable://registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat8-openshift@sha256:e9388df6c16dd0bdfe09b11250598392e590c4a49e9720925644e3f22ed49b56'**,
 'docker-pullable://registry.access.redhat.com/jboss-webserver-3/webserver31-tomcat7-openshift@sha256:9627a7440e6569943fcf0174738fd8182c9a252e105b9bbd3a4eb50e9c94869e',
 'docker-pullable://registry.access.redhat.com/jboss-webserver-3/webserver31-tomcat8-openshift@sha256:aa1f4e422626db5160a4afd026d1db92dcb8fd6ec2eb59b098c9902472682d3f']

example after wrapanapi change, get list with 4 unique images:
ocp_37_prom.mgmt.list_image_id(namespace='test-project-dashboard')
Out[1]: 
['docker-pullable://registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat7-openshift@sha256:81daf7f932be28e8b3d948d86ce6f175a98124ba54dbb40c3609317353f93753',
 'docker-pullable://registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat8-openshift@sha256:e9388df6c16dd0bdfe09b11250598392e590c4a49e9720925644e3f22ed49b56',
 'docker-pullable://registry.access.redhat.com/jboss-webserver-3/webserver31-tomcat7-openshift@sha256:9627a7440e6569943fcf0174738fd8182c9a252e105b9bbd3a4eb50e9c94869e',
 'docker-pullable://registry.access.redhat.com/jboss-webserver-3/webserver31-tomcat8-openshift@sha256:aa1f4e422626db5160a4afd026d1db92dcb8fd6ec2eb59b098c9902472682d3f']