### PR TITLE
[RFR] Don't overwrite class var

### DIFF
--- a/wrapanapi/entities/vm.py
+++ b/wrapanapi/entities/vm.py
@@ -419,7 +419,6 @@ class VmMixin(EntityMixin):
                     "property '{}' must be implemented in class '{}'"
                     .format(prop, self.__class__.__name__)
                 )
-        super(VmMixin, self).__init__(*args, **kwargs)
 
     @abstractproperty
     def can_suspend(self):

--- a/wrapanapi/systems/base.py
+++ b/wrapanapi/systems/base.py
@@ -13,8 +13,8 @@ class System(LoggerMixin):
     """Represents any system that wrapanapi interacts with."""
     __metaclass__ = ABCMeta
 
-    def __init__(self, *args, **kwargs):
-        self._stats_available = {}
+    # This should be defined by implementors of System
+    _stats_available = {}
 
     @abstractproperty
     def _identifying_attrs(self):

--- a/wrapanapi/systems/base.py
+++ b/wrapanapi/systems/base.py
@@ -16,6 +16,17 @@ class System(LoggerMixin):
     # This should be defined by implementors of System
     _stats_available = {}
 
+    def __init__(self, *args, **kwargs):
+        """
+        Constructor for base System.
+
+        System constructor is not doing much right now, but since System child classes
+        may call __super__ in their __init__, we'll store any args that have bubbled up
+        through these super calls
+        """
+        self._base_system_args = args
+        self._base_system_kwargs = kwargs
+
     @abstractproperty
     def _identifying_attrs(self):
         """


### PR DESCRIPTION
Fixes errors like this: `Exception: GoogleCloudSystem has empty self._stats_available dictionary`