### PR TITLE
[RFR] Increase gce delete timeout, change the logic in vm.exists so we don't query for VM twice

### DIFF
--- a/wrapanapi/entities/vm.py
+++ b/wrapanapi/entities/vm.py
@@ -80,13 +80,18 @@ class Vm(Entity):
 
     @property
     def exists(self):
-        """Extend 'exists' method to also check in VM state is deleted."""
-        exists = super(Vm, self).exists
+        """Override entity 'exists' method to check if VM state is deleted."""
+        try:
+            state = self._get_state()
+            exists = True
+        except NotFoundError:
+            exists = False
+
         if exists:
-            state = self.state
-            self.logger.debug("in 'exists' for vm %s, current state: %s", self._log_id, state)
+            # Even if the VM is retrievable, it does not exist if its state is 'DELETED'
             if state == VmState.DELETED:
-                return False
+                exists = False
+
         return exists
 
     @abstractmethod
@@ -94,7 +99,7 @@ class Vm(Entity):
         """
         Returns VMState object representing the VM's current state
 
-        Should call self.refresh() if necessary to get the latest status from the API
+        Should call self.refresh() first to get the latest status from the API
         """
 
     @cached_property_with_ttl(ttl=CACHED_PROPERTY_TTL)

--- a/wrapanapi/entities/vm.py
+++ b/wrapanapi/entities/vm.py
@@ -83,7 +83,9 @@ class Vm(Entity):
         """Extend 'exists' method to also check in VM state is deleted."""
         exists = super(Vm, self).exists
         if exists:
-            if self.state == VmState.DELETED:
+            state = self.state
+            self.logger.debug("in 'exists' for vm %s, current state: %s", self._log_id, state)
+            if state == VmState.DELETED:
                 return False
         return exists
 

--- a/wrapanapi/systems/google.py
+++ b/wrapanapi/systems/google.py
@@ -122,7 +122,7 @@ class GoogleCloudInstance(Instance):
         creation_time = iso8601.parse_date(self.raw['creationTimestamp'])
         return creation_time.astimezone(pytz.UTC)
 
-    def delete(self, timeout=250):
+    def delete(self, timeout=360):
         self.logger.info("Deleting Google Cloud instance '%s'", self.name)
         operation = self._api.delete(
             project=self._project, zone=self.zone, instance=self.name).execute()


### PR DESCRIPTION
Some tests were hitting a TimedOutError waiting for the VM to delete. I'm not hitting this in local tests, my only guess is that the VM was taking a long time to go from "STOPPING" state to completely deleted. 

Also, we were querying for the VM twice (once for self.exists, once again for self.state) -- this will just use `self.state` "to hit 2 birds w/ one stone"