### PR TITLE
[RFR] Add l2 domains to cloud subnets

### DIFF
--- a/wrapanapi/systems/nuage.py
+++ b/wrapanapi/systems/nuage.py
@@ -62,7 +62,9 @@ class NuageSystem(System):
         return self._request_list('/enterprises', 'get')
 
     def list_cloud_subnets(self):
-        return self._request_list('/subnets', 'get', exclude_name='BackHaulSubnet')
+        subnets = self._request_list('/subnets', 'get', exclude_name='BackHaulSubnet')
+        l2domains = self._request_list('/l2domains', 'get')
+        return subnets + l2domains
 
     def list_security_groups(self):
         return self._request_list('/policygroups', 'get')


### PR DESCRIPTION
L2 domains are now inventoried as cloud subnets. They are now added to the list, so num_cloud_subnet now gets correct number of cloud_subnets.