### PR TITLE
[RFR] Update containers rhopenshift openshift list_image_registry to return only registry name

### DIFF
--- a/wrapanapi/systems/container/rhopenshift.py
+++ b/wrapanapi/systems/container/rhopenshift.py
@@ -263,7 +263,8 @@ class Openshift(System):
         for pod in pods:
             for status in pod.status.container_statuses:
                 statuses.append(status)
-        return [status.image for status in statuses]
+        # returns only the image registry name, without the port number in case of local registry
+        return sorted(set([status.image.split('/')[0].split(':')[0] for status in statuses]))
 
     def deploy_template(self, template, tags=None, password='smartvm', **kwargs):
         """Deploy a VM from a template


### PR DESCRIPTION
Update containers rhopenshift openshift method:
- list_image_registry - return only registry name.

No PRT test, please see the following comment