### PR TITLE
Add initial support for Redfish physical provider

### DIFF
--- a/wrapanapi/__init__.py
+++ b/wrapanapi/__init__.py
@@ -9,6 +9,7 @@ from .systems.msazure import AzureSystem
 from .systems.nuage import NuageSystem
 from .systems.openstack import OpenstackSystem
 from .systems.openstack_infra import OpenstackInfraSystem
+from .systems.redfish import RedfishSystem
 from .systems.rhevm import RHEVMSystem
 from .systems.scvmm import SCVMMSystem
 from .systems.vcloud import VmwareCloudSystem
@@ -20,6 +21,6 @@ from .entities.vm import VmState
 __all__ = [
     'EC2System', 'GoogleCloudSystem', 'HawkularSystem',
     'LenovoSystem', 'AzureSystem', 'NuageSystem', 'OpenstackSystem',
-    'OpenstackInfraSystem', 'RHEVMSystem', 'SCVMMSystem', 'VmwareCloudSystem',
-    'VMWareSystem', 'Openshift', 'VmState'
+    'OpenstackInfraSystem', 'RedfishSystem', 'RHEVMSystem', 'SCVMMSystem',
+    'VmwareCloudSystem', 'VMWareSystem', 'Openshift', 'VmState'
 ]

--- a/wrapanapi/systems/__init__.py
+++ b/wrapanapi/systems/__init__.py
@@ -8,6 +8,7 @@ from .msazure import AzureSystem
 from .nuage import NuageSystem
 from .openstack import OpenstackSystem
 from .openstack_infra import OpenstackInfraSystem
+from .redfish import RedfishSystem
 from .rhevm import RHEVMSystem
 from .scvmm import SCVMMSystem
 from .vcloud import VmwareCloudSystem
@@ -15,6 +16,6 @@ from .virtualcenter import VMWareSystem
 
 __all__ = [
     'EC2System', 'GoogleCloudSystem', 'HawkularSystem', 'LenovoSystem',
-    'AzureSystem', 'NuageSystem', 'OpenstackSystem', 'OpenstackInfraSystem',
+    'AzureSystem', 'NuageSystem', 'OpenstackSystem', 'OpenstackInfraSystem', 'RedfishSystem',
     'RHEVMSystem', 'SCVMMSystem', 'VmwareCloudSystem', 'VMWareSystem'
 ]

--- a/wrapanapi/systems/redfish.py
+++ b/wrapanapi/systems/redfish.py
@@ -1,0 +1,37 @@
+# coding: utf-8
+"""Backend management system classes
+Used to communicate with providers without using CFME facilities
+"""
+from __future__ import absolute_import
+
+from wrapanapi.systems.base import System
+
+
+class RedfishSystem(System):
+    """Client to Redfish API
+    Args:
+        hostname: The hostname of the system.
+        username: The username to connect with.
+        password: The password to connect with.
+    """
+
+    _stats_available = {
+        'num_server': lambda self: 1,
+    }
+
+    def __init__(self, hostname, username, password, protocol="https", api_port=443, **kwargs):
+        super(RedfishSystem, self).__init__(kwargs)
+        self.api_port = api_port
+        self.auth = (username, password)
+        self.url = '{}://{}:{}/'.format(protocol, hostname, self.api_port)
+        self.kwargs = kwargs
+
+    @property
+    def _identifying_attrs(self):
+        return {'url': self.url}
+
+    def info(self):
+        return 'RedfishSystem url={}'.format(self.url)
+
+    def __del__(self):
+        """Disconnect from the API when the object is deleted"""


### PR DESCRIPTION
This commit contains the bare minimum support for the API to be
used by the integration tests, which test the Redfish type of
the [physical infrastructure providers](https://github.com/ManageIQ/manageiq-providers-redfish).
The API implementation currently does not yet make any actual
Redfish client calls. Instead, it encodes the state as we expect
it from the [mock-up server](https://github.com/xlab-si/redfish-recordings).
In this commit, we only validate the number of servers disovered
by the provider.

/cc @gberginc @tadeboro