### PR TITLE
[RFR] Do not refresh the VM after marking it as template

### DIFF
--- a/wrapanapi/systems/virtualcenter.py
+++ b/wrapanapi/systems/virtualcenter.py
@@ -526,8 +526,9 @@ class VMWareVirtualMachine(VMWareVMOrTemplate, Vm):
 
     def mark_as_template(self, **kwargs):
         self.raw.MarkAsTemplate()
-        self.refresh()
-        return VMWareTemplate(system=self.system, name=self.name, raw=self.raw)
+        template = VMWareTemplate(system=self.system, name=self.name, raw=self.raw)
+        template.refresh()
+        return template
 
     def clone(self, vm_name, **kwargs):
         kwargs['destination'] = vm_name


### PR DESCRIPTION
Fixes this error when calling vm.mark_as_template() for a virtualcenter VM:
```
../cfme_venv/lib/python2.7/site-packages/wrapanapi/systems/virtualcenter.py:815: Exception
Exception
Looking for VM but found template of name 'test_rest_vm_LocI'
```
The problem is that `self.refresh()` was being called on the VM after it has been marked as a template. `self.refresh()` in turn calls `get_vm(self.name)` which fails because it finds a template object with `name=self.name` instead of a VM with that name