### PR TITLE
Allow vmware clone to same name on relocate=True

### DIFF
--- a/wrapanapi/systems/virtualcenter.py
+++ b/wrapanapi/systems/virtualcenter.py
@@ -255,7 +255,7 @@ class VMWareVMOrTemplate(Entity):
             vm = self.system.get_vm(destination)
         except VMInstanceNotFound:
             vm = None
-        if vm:
+        if vm and not relocate:
             raise Exception("VM/template of the name {} already present!".format(destination))
 
         if progress_callback is None:
@@ -524,10 +524,13 @@ class VMWareVirtualMachine(VMWareVMOrTemplate, Vm):
         self.ensure_state(VmState.STOPPED)
         return super(VMWareVirtualMachine, self).delete()
 
-    def mark_as_template(self, **kwargs):
+    def mark_as_template(self, template_name=None, **kwargs):
+        self.ensure_state(VmState.STOPPED)
         self.raw.MarkAsTemplate()
         template = VMWareTemplate(system=self.system, name=self.name, raw=self.raw)
         template.refresh()
+        if template_name and template_name != template.name:
+            template.rename(template_name)
         return template
 
     def clone(self, vm_name, **kwargs):


### PR DESCRIPTION
`clone`, being used for relocate, should allow the name to stay the same.

`mark_as_template` should allow for passing a new name for the template, like all other providers implementing this method do. Call rename after creating the template.

Including bug label because the call to mark_as_template fails if the VM is still running, other system implementations stop the VM before marking template.