### PR TITLE
[RFR] Make ip property return IPv4 address (RHV)

### DIFF
--- a/wrapanapi/systems/rhevm.py
+++ b/wrapanapi/systems/rhevm.py
@@ -166,14 +166,13 @@ class RHEVMVirtualMachine(_SharedMethodsMixin, Vm):
     @property
     def ip(self):
         """
-        Returns IP address of the VM/instance
+        Returns IPv4 or global IPv6 address of the VM/instance
         """
-        rep_dev_service = self.api.reported_devices_service()
-        try:
-            first = rep_dev_service.list()[0]
-            return first.ips[0].address
-        except IndexError:
-            return None
+        link_local_prefix = 'fe80::'
+        for ip in self.all_ips:
+            if link_local_prefix not in ip[:len(link_local_prefix)]:
+                return ip
+        return None
 
     @property
     def all_ips(self):


### PR DESCRIPTION
VM is often assigned an IPv6 link-local address way before
IPv6 global or IPv4 address.

Subsequent attempt to SSH to such machine then fails, unless we pick
the right address. This is a problem for example in ssa tests:
https://github.com/ManageIQ/integration_tests/blob/6b09a70d1463ad410c09e46fc27bd0eedb21653f/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py#L257

In such case, waiting for IP is pointless, because in the first call is returned the 
link-local IP address.

In this PR, I changed the the vm ip property to by default return None
until IPv4 address is found in the assigned ip addresses.