### PR TITLE
[RFR] Changing way to create the ssl context as TLSv1.0 is disabled by VMware for vSphere 6.7

### DIFF
--- a/wrapanapi/systems/virtualcenter.py
+++ b/wrapanapi/systems/virtualcenter.py
@@ -633,7 +633,7 @@ class VMWareSystem(System, VmMixin, TemplateMixin):
         """
         try:
             # Disable SSL cert verification
-            context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+            context = ssl._create_unverified_context()
             context.verify_mode = ssl.CERT_NONE
             si = SmartConnect(
                 host=self.hostname,


### PR DESCRIPTION
This upate is made based on 
https://github.com/vmware/pyvmomi/issues/694#issuecomment-400124246
and https://kb.vmware.com/s/article/2145796

Tested to work against vSphere 5.5/6.0/6.5/6.7 using calling methods below:
```

provider.mgmt.list_cluster()
provider.mgmt.list_vms()
provider.mgmt.list_datastore()
provider.mgmt.list_templates()
provider.mgmt.list_host()

```