### PR TITLE
[RFR] Adds Redfish API client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ python-novaclient==7.1.2
 python-heatclient
 pyvcloud==19.1.2
 pywinrm
+redfish-client==0.1.0
 requests
 six
 tzlocal

--- a/wrapanapi/entities/__init__.py
+++ b/wrapanapi/entities/__init__.py
@@ -7,8 +7,9 @@ from .template import Template, TemplateMixin
 from .vm import Vm, VmState, VmMixin
 from .instance import Instance
 from .stack import Stack, StackMixin
+from .server import Server, ServerState
 
 __all__ = [
     'Template', 'TemplateMixin', 'Vm', 'VmState', 'VmMixin', 'Instance',
-    'Stack', 'StackMixin'
+    'Server', 'ServerState', 'Stack', 'StackMixin'
 ]

--- a/wrapanapi/entities/server.py
+++ b/wrapanapi/entities/server.py
@@ -1,0 +1,108 @@
+"""
+wrapanapi.entities.server
+
+Implements classes and methods related to actions performed on (physical) servers
+"""
+import six
+from abc import ABCMeta, abstractmethod
+
+from wrapanapi.entities.base import Entity
+
+
+class ServerState(object):
+    """
+    Represents a state for a server on the provider system.
+
+    Implementations of ``Server`` should map to these states
+    """
+    ON = 'ServerState.On'
+    OFF = 'ServerState.Off'
+    POWERING_ON = 'ServerState.PoweringOn'
+    POWERING_OFF = 'ServerState.PoweringOff'
+    UNKNOWN = 'ServerState.Unknown'
+
+    @classmethod
+    def valid_states(cls):
+        return [
+            var_val for _, var_val in vars(cls).items()
+            if isinstance(var_val, six.string_types) and var_val.startswith('ServerState.')
+        ]
+
+
+class Server(Entity):
+    """
+    Represents a single server on a management system.
+    """
+    __metaclass__ = ABCMeta
+    # Implementations must define a dict which maps API states returned by the
+    # system to a ServerState. Example:
+    #    {'On': ServerState.ON, 'Off': ServerState.OFF}
+    state_map = None
+
+    def __init__(self, *args, **kwargs):
+        """
+        Verify the required class variables are implemented during init
+
+        Since abc has no 'abstract class property' concept, this is the approach taken.
+        """
+        state_map = self.state_map
+        if (not state_map or not isinstance(state_map, dict) or
+                not all(value in ServerState.valid_states() for value in state_map.values())):
+            raise NotImplementedError(
+                "property '{}' not properly implemented in class '{}'"
+                .format('state_map', self.__class__.__name__)
+            )
+        super(Server, self).__init__(*args, **kwargs)
+
+    def _api_state_to_serverstate(self, api_state):
+        """
+        Use the state_map for this instance to map a state string into a ServerState constant
+        """
+        try:
+            return self.state_map[api_state]
+        except KeyError:
+            self.logger.warn(
+                "Unmapped Server state '%s' received from system, mapped to '%s'",
+                api_state, ServerState.UNKNOWN
+            )
+            return ServerState.UNKNOWN
+
+    @abstractmethod
+    def _get_state(self):
+        """
+        Return ServerState object representing the server's current state.
+
+        Should call self.refresh() first to get the latest status from the API
+        """
+
+    def delete(self):
+        """Remove the entity on the provider. Not supported on servers."""
+        raise NotImplementedError("Deleting not supported for servers")
+
+    def cleanup(self):
+        """
+        Remove the entity on the provider and any of its associated resources.
+
+        Not supported on servers.
+        """
+        raise NotImplementedError("Cleanup not supported for servers")
+
+    @property
+    def is_on(self):
+        """Return True if the server is powered on."""
+        return self._get_state() == ServerState.ON
+
+    @property
+    def is_off(self):
+        """Return True if the server is powered off."""
+        return self._get_state() == ServerState.OFF
+
+    @property
+    def is_powering_on(self):
+        """Return True if the server is in the process of being powered on."""
+        return self._get_state() == ServerState.POWERING_ON
+
+    @property
+    def is_powering_off(self):
+        """Return True if the server is in the process of powered off."""
+        return self._get_state() == ServerState.POWERING_OFF

--- a/wrapanapi/systems/redfish.py
+++ b/wrapanapi/systems/redfish.py
@@ -38,8 +38,54 @@ class RedfishSystem(System):
     def info(self):
         return 'RedfishSystem url={}'.format(self.url)
 
-    def __del__(self):
-        """Disconnect from the API when the object is deleted"""
+    def server_stats(self, physical_server, requested_stats, **kwargs):
+        """
+        Evaluate the requested server stats at the API server.
 
+        Returns a dictionary of stats and their respective evaluated values.
+
+        Args:
+          physical_server: representation for the class of this method's caller
+          requested_stats: the statistics to be obtained
+        """
+        # Retrieve and return the stats
+        requested_stats = requested_stats or self._stats_available
+
+        # Get an instance of the requested Redfish server
+        redfish_server = self.get_server(physical_server.ems_ref)
+
+        return {stat: self._server_stats_available[stat](redfish_server)
+                for stat in requested_stats}
+
+    def server_inventory(self, physical_server, requested_items, **kwargs):
+        """
+        Evaluate the requested inventory item statuses at the API server.
+
+        Returns a dictionary of items and their respective evaluated values.
+
+        Args:
+          physical_server: representation for the class of this method's caller
+          requested_items: the inventory items to be obtained for the server
+        """
+        # Retrieve and return the inventory
+        requested_items = requested_items or self._server_inventory_available
+
+        # Get an instance of the requested Redfish server
+        redfish_server = self.get_server(physical_server.ems_ref)
+
+        return {item: self._server_inventory_available[item](redfish_server)
+                for item in requested_items}
+
+    def get_server(self, resource_id):
+        """
+        Fetch a RedfishServer instance of the physical server representing resource_id.
+
+        Args:
+          resource_id: the Redfish @odata.id of the resource representing the
+             server to be retrieved
+        """
+        return RedfishServer(self, raw=self.api_client.find(resource_id))
+
+    @property
     def num_servers(self):
         return len(self.api_client.Systems.Members)


### PR DESCRIPTION
With this PR we replace the hard-coded value for the stat check with that obtained by the Redfish provider's implementation now uses [the Redfish API client](https://pypi.org/project/redfish-client/).

We initiated a new entity `Server` and contributed `ServerStats` enum, which `RedfishServer` implements with its API specifics. The `RedfishSystem` is implemented such that it can be used both for testing stats at the provider level and for a selected physical server instance.

~~Depends on https://github.com/ManageIQ/integration_tests/pull/7735 and https://github.com/ManageIQ/wrapanapi/pull/331.~~

/cc @tadeboro, @miha-plesko 