### PR TITLE
[RFR] Fix ensure_state fail when VM is in starting state

### DIFF
--- a/wrapanapi/entities/vm.py
+++ b/wrapanapi/entities/vm.py
@@ -276,7 +276,9 @@ class Vm(Entity):
         elif state == VmState.STOPPED:
             return self._handle_transition(
                 in_desired_state=lambda: self.is_stopped,
-                in_state_requiring_prep=lambda: self.is_suspended or self.is_paused,
+                in_state_requiring_prep=lambda: (self.is_suspended or
+                                                 self.is_paused or
+                                                 self.is_starting),
                 in_actionable_state=lambda: self.is_running,
                 do_prep=self.start,
                 do_action=self.stop,


### PR DESCRIPTION
This PR fixes scenarios where method ensure_state(VmState.STOPPED) is called:
https://github.com/ManageIQ/wrapanapi/blob/ad764e7e5a50773a12e614f5a4f05e83d8e2bd93/wrapanapi/systems/rhevm.py#L182

If I understand correctly, the problem is that this method is sometimes called when the VM to be deleted is in state VmState.STARTING. Subsequently, this call doesn't wait for the VM to get to  VmState.RUNNIG and the self.stop action is called right away:

https://github.com/ManageIQ/wrapanapi/blob/ad764e7e5a50773a12e614f5a4f05e83d8e2bd93/wrapanapi/entities/vm.py#L282

The result is then the following exception:
Error: Fault reason is "Operation Failed". Fault detail is "[Cannot remove VM. VM is running.]". HTTP response code is 409.

This can be observed for example in PRT in test cases that remove the VM relatively shortly after provisioning is completed:
http://infra-trackerbot2.cfme2.lab.eng.rdu2.redhat.com/pr/run/25936