### PR TITLE
[RFR] Add API for Redfish chassis navigation

### DIFF
--- a/wrapanapi/entities/__init__.py
+++ b/wrapanapi/entities/__init__.py
@@ -6,10 +6,11 @@ from __future__ import absolute_import
 from .template import Template, TemplateMixin
 from .vm import Vm, VmState, VmMixin
 from .instance import Instance
+from .physical_container import PhysicalContainer
 from .stack import Stack, StackMixin
 from .server import Server, ServerState
 
 __all__ = [
     'Template', 'TemplateMixin', 'Vm', 'VmState', 'VmMixin', 'Instance',
-    'Server', 'ServerState', 'Stack', 'StackMixin'
+    'PhysicalContainer', 'Server', 'ServerState', 'Stack', 'StackMixin'
 ]

--- a/wrapanapi/entities/base.py
+++ b/wrapanapi/entities/base.py
@@ -6,13 +6,14 @@ Provides method/class definitions for handling any entity on a provider
 from __future__ import absolute_import
 
 from abc import ABCMeta, abstractmethod, abstractproperty
+import six
 from six.moves import reprlib
 
 from wrapanapi.utils import LoggerMixin
 from wrapanapi.exceptions import NotFoundError
 
 
-class Entity(LoggerMixin):
+class Entity(six.with_metaclass(ABCMeta, LoggerMixin)):
     """
     Base class to represent any object on a provider system as well
     as methods for manipulating that entity (deleting, renaming, etc.)
@@ -20,8 +21,6 @@ class Entity(LoggerMixin):
     Provides properties/methods that should be applicable
     across all entities on all systems.
     """
-    __metaclass__ = ABCMeta
-
     def __init__(self, system, raw=None, **kwargs):
         """
         Constructor for an entity

--- a/wrapanapi/entities/instance.py
+++ b/wrapanapi/entities/instance.py
@@ -4,19 +4,18 @@ wrapanapi.entities.instance
 Instances which run on cloud providers
 """
 from __future__ import absolute_import
+import six
 
 from abc import ABCMeta, abstractproperty
 
 from .vm import Vm
 
 
-class Instance(Vm):
+class Instance(six.with_metaclass(ABCMeta, Vm)):
     """
     Adds a few additional properties/methods pertaining to VMs hosted
     on a cloud platform.
     """
-    __metaclass__ = ABCMeta
-
     @abstractproperty
     def type(self):
         """

--- a/wrapanapi/entities/physical_container.py
+++ b/wrapanapi/entities/physical_container.py
@@ -7,15 +7,13 @@ blocks, sleds, chassis or enclosures that contain other physical entities such
 as physical servers.
 """
 from abc import ABCMeta
+import six
 
 from wrapanapi.entities.base import Entity
 
 
-class PhysicalContainer(Entity):
-    """
-    Represents a single physical container.
-    """
-    __metaclass__ = ABCMeta
+class PhysicalContainer(six.with_metaclass(ABCMeta, Entity)):
+    """Represents a single physical container."""
 
     def delete(self):
         """Remove the entity on the provider. Not supported on physical containers."""

--- a/wrapanapi/entities/physical_container.py
+++ b/wrapanapi/entities/physical_container.py
@@ -1,0 +1,30 @@
+# coding: utf-8
+"""
+wrapanapi.entities.physical_container
+
+Implements classes and methods related to physical entities such as racks,
+blocks, sleds, chassis or enclosures that contain other physical entities such
+as physical servers.
+"""
+from abc import ABCMeta
+
+from wrapanapi.entities.base import Entity
+
+
+class PhysicalContainer(Entity):
+    """
+    Represents a single physical container.
+    """
+    __metaclass__ = ABCMeta
+
+    def delete(self):
+        """Remove the entity on the provider. Not supported on physical containers."""
+        raise NotImplementedError("Deleting not supported for physical containers")
+
+    def cleanup(self):
+        """
+        Remove the entity on the provider and any of its associated resources.
+
+        Not supported on physical containers.
+        """
+        raise NotImplementedError("Cleanup not supported for physical containers")

--- a/wrapanapi/entities/server.py
+++ b/wrapanapi/entities/server.py
@@ -29,11 +29,10 @@ class ServerState(object):
         ]
 
 
-class Server(Entity):
+class Server(six.with_metaclass(ABCMeta, Entity)):
     """
     Represents a single server on a management system.
     """
-    __metaclass__ = ABCMeta
     # Implementations must define a dict which maps API states returned by the
     # system to a ServerState. Example:
     #    {'On': ServerState.ON, 'Off': ServerState.OFF}

--- a/wrapanapi/entities/stack.py
+++ b/wrapanapi/entities/stack.py
@@ -4,6 +4,7 @@ wrapanapi.entities.stack
 Orchestration stacks
 """
 from __future__ import absolute_import
+import six
 
 from abc import ABCMeta, abstractmethod
 
@@ -11,12 +12,10 @@ from wrapanapi.entities.base import Entity, EntityMixin
 from wrapanapi.exceptions import MultipleItemsError, NotFoundError
 
 
-class Stack(Entity):
+class Stack(six.with_metaclass(ABCMeta, Entity)):
     """
     Defines methods/properties pertaining to stacks
     """
-    __metaclass__ = ABCMeta
-
     @abstractmethod
     def get_details(self):
         """
@@ -31,12 +30,10 @@ class Stack(Entity):
         """
 
 
-class StackMixin(EntityMixin):
+class StackMixin(six.with_metaclass(ABCMeta, EntityMixin)):
     """
     Defines methods for systems that support stacks
     """
-    __metaclass__ = ABCMeta
-
     @abstractmethod
     def list_stacks(self, **kwargs):
         """

--- a/wrapanapi/entities/template.py
+++ b/wrapanapi/entities/template.py
@@ -3,18 +3,18 @@ wrapanapi.entities.template
 
 Methods/classes pertaining to performing actions on a template
 """
+import six
+
 from abc import ABCMeta, abstractmethod
 
 from wrapanapi.entities.base import Entity, EntityMixin
 from wrapanapi.exceptions import MultipleItemsError, NotFoundError
 
 
-class Template(Entity):
+class Template(six.with_metaclass(ABCMeta, Entity)):
     """
     Represents a template on a system
     """
-    __metaclass__ = ABCMeta
-
     @abstractmethod
     def deploy(self, vm_name, timeout, **kwargs):
         """
@@ -24,12 +24,10 @@ class Template(Entity):
         """
 
 
-class TemplateMixin(EntityMixin):
+class TemplateMixin(six.with_metaclass(ABCMeta, EntityMixin)):
     """
     Defines methods a wrapanapi.systems.System that manages Templates should have
     """
-    __metaclass__ = ABCMeta
-
     @abstractmethod
     def get_template(self, name, **kwargs):
         """

--- a/wrapanapi/entities/vm.py
+++ b/wrapanapi/entities/vm.py
@@ -5,7 +5,7 @@ Methods/classes pertaining to performing actions on a VM/instance
 """
 import time
 from abc import ABCMeta, abstractmethod, abstractproperty
-from six import string_types
+from six import string_types, with_metaclass
 
 from cached_property import cached_property_with_ttl
 from wait_for import wait_for, TimedOutError
@@ -41,12 +41,10 @@ class VmState(object):
         ]
 
 
-class Vm(Entity):
+class Vm(with_metaclass(ABCMeta, Entity)):
     """
     Represents a single VM/instance on a management system.
     """
-    __metaclass__ = ABCMeta
-
     # Implementations must define a dict which maps API states returned by the
     # system to a VmState. Example:
     #    {'running': VmState.RUNNING, 'shutdown': VmState.STOPPED}
@@ -410,12 +408,10 @@ class Vm(Entity):
         )
 
 
-class VmMixin(EntityMixin):
+class VmMixin(with_metaclass(ABCMeta, EntityMixin)):
     """
     Defines methods or properties a wrapanapi.systems.System that manages Vm's should have
     """
-    __metaclass__ = ABCMeta
-
     # Implementations must define whether this system can suspend (True/False)
     can_suspend = None
     # Implementations must define whether this system can pause (True/False)

--- a/wrapanapi/systems/base.py
+++ b/wrapanapi/systems/base.py
@@ -4,15 +4,14 @@
 Used to communicate with providers without using CFME facilities
 """
 from __future__ import absolute_import
+import six
 from abc import ABCMeta, abstractmethod, abstractproperty
 
 from wrapanapi.utils import LoggerMixin
 
 
-class System(LoggerMixin):
+class System(six.with_metaclass(ABCMeta, LoggerMixin)):
     """Represents any system that wrapanapi interacts with."""
-    __metaclass__ = ABCMeta
-
     # This should be defined by implementors of System
     _stats_available = {}
 

--- a/wrapanapi/systems/redfish.py
+++ b/wrapanapi/systems/redfish.py
@@ -104,6 +104,8 @@ class RedfishSystem(System):
     # statistics for the provider
     _stats_available = {
         'num_server': lambda self: self.num_servers,
+        'num_chassis': lambda self: self.num_chassis,
+        'num_racks': lambda self: self.num_racks,
     }
 
     # statistics for an individual server
@@ -182,3 +184,15 @@ class RedfishSystem(System):
     def num_servers(self):
         """Return the number of servers discovered by the provider."""
         return len(self.api_client.Systems.Members)
+
+    @property
+    def num_chassis(self):
+        """Return the count of Physical Chassis discovered by the provider."""
+        return len([chassis for chassis in self.api_client.Chassis.Members
+            if chassis.ChassisType != "Rack"])
+
+    @property
+    def num_racks(self):
+        """Return the number of Physical Racks discovered by the provider."""
+        return len([rack for rack in self.api_client.Chassis.Members
+            if rack.ChassisType == "Rack"])


### PR DESCRIPTION
We expand the Redfish API implementation to include retrieval and inspection of Chassis resources.

This PR introduces class `RedfishResource` that abstracts Redfish entities such as `Systems`, `Chassis` or `EventService`.

In the context of physical infrastructure, servers normally reside in one or more nested enclosures such as chassis or racks. This new entity serves as a reporesentation of these physical containers. Not to be confused by container virtualisation technology.

The Redfish API now supports retrieving Chassis resources, which are general chassis entities. It also provides helper methods for retrieving physical racks, which are a special type of Chassis. The Redfish racks currently support getting the name of the rack. The Redfish chassis support obtaining chassis name and description, status of the identifying LED (if available) and the number of servers installed within the chassis.

Related Bugzilla tickets:
  * https://bugzilla.redhat.com/show_bug.cgi?id=1571610
  * https://bugzilla.redhat.com/show_bug.cgi?id=1574809