### PR TITLE
Tagged name should have higher priority than AMI name

### DIFF
--- a/wrapanapi/systems/ec2.py
+++ b/wrapanapi/systems/ec2.py
@@ -311,7 +311,7 @@ class EC2Image(Template, _TagMixin):
 
     @property
     def name(self):
-        return self.raw.name or self.raw.tags.get('Name', self.raw.id)
+        return self.raw.tags.get('Name') or self.raw.name or self.raw.id
 
     @property
     def uuid(self):


### PR DESCRIPTION
Priority should be like this:
tagged name > ami name > ami id(shouldn't happen as ami name is required)