### PR TITLE
Update requirements for pyvmomi, openshift, python-novaclient

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,21 +6,21 @@ boto
 cached_property
 dateparser
 enum34; python_version == '2.7'
-fauxfactory>=2.0.7
+fauxfactory
 google-api-python-client
 google-compute-engine
 inflection
 miq-version>=0.1.6
 oauth2client
 ovirt-engine-sdk-python>=4.0.0,<5.0.0
-openshift==0.3.4
+openshift==0.7.2
 packaging
-pyvmomi>=6.5.0.2017.5.post1
+pyvmomi>=6.7.0
 python-cinderclient
 python-glanceclient
 python-ironicclient
 python-keystoneclient
-python-novaclient==7.1.2
+python-novaclient==11.1.0
 python-heatclient
 pyvcloud==19.1.2
 pywinrm


### PR DESCRIPTION
some mis-matches on versions supported by dependent libraries

python-novaclient is non-trivial update, as `novaclient.v2.floating_ips` module was removed, along with its `FloatingIP` class that we were using.