### PR TITLE
[RFR] wrongly updated method during wrapanapi 3.0 conversion

### DIFF
--- a/wrapanapi/systems/rhevm.py
+++ b/wrapanapi/systems/rhevm.py
@@ -368,7 +368,7 @@ class RHEVMVirtualMachine(_SharedMethodsMixin, Vm):
     def get_hardware_configuration(self):
         self.refresh()
         return {
-            'ram': self.raw.memory,
+            'ram': self.raw.memory / 1024 / 1024,
             'cpu': self.raw.cpu.topology.cores * self.raw.cpu.topology.sockets
         }
 

--- a/wrapanapi/systems/scvmm.py
+++ b/wrapanapi/systems/scvmm.py
@@ -223,7 +223,7 @@ class SCVirtualMachine(Vm, _LogStrMixin):
 
     def get_hardware_configuration(self):
         self.refresh(read_from_hyperv=True)
-        data = {'mem': self.raw['CPUCount'], 'cpu': self.raw['Memory']}
+        data = {'mem': self.raw['Memory'], 'cpu': self.raw['CPUCount']}
         return {
             key: str(val) if isinstance(val, six.string_types) else val
             for key, val in data.items()


### PR DESCRIPTION
Some sprout tasks fail during vm hardware configuration update because get_vm_hardware methods return memory in bytes instead of MB