### PR TITLE
[RFR] Add Support For Datastore Clusters for Vmware

### DIFF
--- a/wrapanapi/exceptions.py
+++ b/wrapanapi/exceptions.py
@@ -60,6 +60,16 @@ class LabelNotFoundException(NotFoundError):
             self._label_key)
 
 
+class DatastoreNotFoundError(NotFoundError):
+    """Raised if a datastore(s) or datastore clusters(s) are not found"""
+    def __init__(self, item_type):
+        self.item_type = item_type
+
+    def __str__(self):
+        return 'Could not find any "{}" available for provisioning, check the status'.format(
+            self.item_type)
+
+
 class NetworkNameNotFound(NotFoundError):
     pass
 


### PR DESCRIPTION
This PR introduces the ability to clone or relocate a VM/template on a datastore cluster. 

For deploying on a datastore, `CloneVM_Task` is replaced by `RecommandedDatastores` and `ApplyStorageDrsRecommendation_Task`. This is because `CloneVm_Task` forces you to specify the specific datastore for your new VM. 

Testing:

You can either specify a datastore object (vim.Datastore), datastore cluster object (vim.StoragePod), or the name (string) of the datastore or datastore cluster.

If no datastore is provided,  it is picked in the following order:
1) If the kwarg `allowed_datastores` is passed, the a datastore is picked from the list with the most free space to capacity ratio and if it 
a) accessible
b) Multiple Host access
c) Overall status is not red
2) If there is a datastore cluster(s), pick a datastore cluster based on free space to capacity ratio and the overrall status is not red.
3) Use the same datastore as the template

To list all datastore clusters on a Vmware provider:
```
In[7]: vmware = providers.get_crud('infra-vcenter65-sprout1')
In[8]: vmware.mgmt.list_datastore_cluster()
Out[8]: ['DatastoreCluster']
```

To get a datastore cluster vim object based on a name:
```
vmware.mgmt.get_datastore(datastore_name='DatastoreCluster')
Out[9]: 'vim.StoragePod:group-p20'
```

Deploy a template:

Defined Datastore:
```
In[41]: vmware.mgmt.get_datastore(datastore_name='smicro-5037-04_localdisk')
Out[41]: 'vim.Datastore:datastore-15'
In[42]: vm_datastore = temp.deploy('juwatts-test-datastore-1', datastore='smicro-5037-04_localdisk')
In[44]: vm_datastore._raw.datastore
Out[44]: 
(ManagedObject) [
   'vim.Datastore:datastore-15'
]
```
Defined Datastore Cluster:
```
In[15]: vmware = providers.get_crud('infra-vcenter65-sprout1')
In[16]: sc = vmware.mgmt.list_datastore_cluster()[0]
In[17]: sc
Out[17]: 'DatastoreCluster'
In[18]: temp = vmware.mgmt.list_templates()[1]
In[19]: temp
Out[19]: <wrapanapi.systems.virtualcenter.VMWareTemplate system=<VMWareSystem> raw=<__builtin__.NoneType>, kwargs['name']='cfme-5.10.0.33-20190130'>
In[20]: vm = temp.deploy('juwatts-test-cluster-1', datastore=sc)
In[21]: vm
Out[21]: <wrapanapi.systems.virtualcenter.VMWareVirtualMachine system=<VMWareSystem> raw=<pyVmomi.VmomiSupport.vim.VirtualMachine>, kwargs['name']='juwatts-test-cluster-1'>
In[22]: vm.is_running
Out[22]: True
In[23]: vm._raw.datastore
Out[23]: 
(ManagedObject) [
   'vim.Datastore:datastore-11'
]

```

Clone a VM:

Datastore:
```
In[54]: vmware.mgmt.get_datastore(datastore_name='cfme-smicro-628-b02_localdisk')
Out[54]: 'vim.Datastore:datastore-11'
In[55]: vm_datastore
Out[55]: <wrapanapi.systems.virtualcenter.VMWareVirtualMachine system=<VMWareSystem> raw=<pyVmomi.VmomiSupport.vim.VirtualMachine>, kwargs['name']='juwatts-test-datastore-1'>
In[56]: vm_datastore._raw.datastore
Out[56]: 
(ManagedObject) [
   'vim.Datastore:datastore-15'
]
In[57]: vm_clone_datastore = vm_datastore.clone('juwatts-test-clone-datastore', datastore='cfme-smicro-628-b02_localdisk')
In[58]: vm_clone_datastore
Out[58]: <wrapanapi.systems.virtualcenter.VMWareVirtualMachine system=<VMWareSystem> raw=<__builtin__.NoneType>, kwargs['name']='juwatts-test-clone-datastore'>
In[59]: vm_clone_datastore.raw.datastore
Out[59]: 
(ManagedObject) [
   'vim.Datastore:datastore-11'
]
```

Datastore Cluster:
```
In[25]: vm
Out[25]: <wrapanapi.systems.virtualcenter.VMWareVirtualMachine system=<VMWareSystem> raw=<pyVmomi.VmomiSupport.vim.VirtualMachine>, kwargs['name']='juwatts-test-cluster-1'>
In[26]: vm_clone = vm.clone('juwatts-test-vm-clone', datastore=sc)
In[27]: vm_clone
Out[27]: <wrapanapi.systems.virtualcenter.VMWareVirtualMachine system=<VMWareSystem> raw=<__builtin__.NoneType>, kwargs['name']='juwatts-test-vm-clone'>
In[28]: vmware.mgmt.list_vms()
Out[28]: 
 <wrapanapi.systems.virtualcenter.VMWareVirtualMachine system=<VMWareSystem> raw=<__builtin__.NoneType>, kwargs['name']='juwatts-test-cluster-1'>,
 <wrapanapi.systems.virtualcenter.VMWareVirtualMachine system=<VMWareSystem> raw=<__builtin__.NoneType>, kwargs['name']='juwatts-test-vm-clone'>,
 <wrapanapi.systems.virtualcenter.VMWareVirtualMachine system=<VMWareSystem> raw=<__builtin__.NoneType>, kwargs['name']='VMware vCenter Server Appliance'>]
In[36]: vm_clone.raw.datastore
Out[36]: 
(ManagedObject) [
   'vim.Datastore:datastore-11'
]

```