### PR TITLE
[RFR] fixed count of templates for Azure

### DIFF
--- a/wrapanapi/systems/msazure.py
+++ b/wrapanapi/systems/msazure.py
@@ -455,7 +455,7 @@ class AzureSystem(System, VmMixin, TemplateMixin):
     """
     _stats_available = {
         'num_vm': lambda self: len(self.list_vms()),
-        'num_template': lambda self: len(self.list_templates()),
+        'num_template': lambda self: len(list(self.list_compute_images())),
     }
 
     can_suspend = True


### PR DESCRIPTION
This affects `test_azure_multiple_subscription` that was not passed in automation for quite some time. Finally, I dug into this and the problem was here.

`list_templates` is essentially `find_templates` that finds all images in all containers.
What we need here is `list_compute_images` as it returns the same result as in `Azure portal -> Images`, that corresponds to `CFME -> Provider -> Images`.