### PR TITLE
[RFR] SCVMM: Removing generic refresh function as it is redundant and broken 

### DIFF
--- a/wrapanapi/systems/scvmm.py
+++ b/wrapanapi/systems/scvmm.py
@@ -618,7 +618,7 @@ class SCVMMSystem(System, VmMixin, TemplateMixin):
         """.format(url=url, name=name, dest=dest)
         self.run_script(script)
         # refresh the library so it's available for SCVMM to use
-        self.refresh_library()
+        self.update_scvmm_library(dest)
 
     def delete_file(self, name, dest="L:\\Library\\VHDs\\"):
         """ Deletes a file from the SCVMM library """
@@ -628,15 +628,7 @@ class SCVMMSystem(System, VmMixin, TemplateMixin):
             Remove-Item -Path $fname
         """.format(name=name, dest=dest)
         self.run_script(script)
-        self.refresh_library()
-
-    def refresh_library(self):
-        """ Perform a generic refresh of the SCVMM library """
-        self.logger.info("Refreshing VMM library...")
-        script = """
-            Refresh-LibraryShare
-        """
-        self.run_script(script)
+        self.update_scvmm_library(dest)
 
     class PowerShellScriptError(Exception):
         pass

--- a/wrapanapi/systems/scvmm.py
+++ b/wrapanapi/systems/scvmm.py
@@ -630,5 +630,14 @@ class SCVMMSystem(System, VmMixin, TemplateMixin):
         self.run_script(script)
         self.update_scvmm_library(dest)
 
+    def delete_vhd(self, name):
+        """ Deletes a vhd or vhdx file """
+        self.logger.info("Removing the vhd {} from the library".format(name))
+        script = """
+            $vhd = Get-SCVirtualHardDisk -Name "{}"
+            Remove-SCVirtualHardDisk -VirtualHardDisk $vhd
+        """.format(name)
+        self.run_script(script)
+
     class PowerShellScriptError(Exception):
         pass


### PR DESCRIPTION
The `refresh_library` function for scvmm hangs, and has been replaced by `Read-SCLibraryShare`, which is already provided by `update_scvmm_library`. This PR is fixing the errors made in #378  

Also adding a function to delete vhd's safely from SCVMM.