### PR TITLE
[RFR] fixed set and unset tag for ec2

### DIFF
--- a/wrapanapi/systems/ec2.py
+++ b/wrapanapi/systems/ec2.py
@@ -31,7 +31,8 @@ def _regions(regionmodule, regionname):
 
 class _TagMixin(object):
     def set_tag(self, key, value):
-        self.system.ec2_connection.create_tags(Resources=[self.uuid], Tags={key: value})
+        self.system.ec2_connection.create_tags(Resources=[self.uuid],
+                                               Tags=[{"Key": key, "Value": value}])
 
     def get_tag_value(self, key):
         self.refresh()
@@ -42,7 +43,8 @@ class _TagMixin(object):
         return None
 
     def unset_tag(self, key, value):
-        self.system.ec2_connection.delete_tags(Resources=[self.uuid], Tags={key: value})
+        self.system.ec2_connection.delete_tags(Resources=[self.uuid],
+                                               Tags=[{"Key": key, "Value": value}])
 
 
 class EC2Instance(Instance, _TagMixin):


### PR DESCRIPTION
this fixes `cfme/tests/cloud/test_tag_mapping.py::test_labels_update[instances-ec2] FAILED`

example error was as follows
```
<type 'tuple'>: (<class 'botocore.exceptions.ParamValidationError'>, ParamValidationError(u"Parameter validation failed:\nInvalid type for parameter Tags, value: {'tag_label_WWh8gjm227': 'tag_value_AOAuvsaOGY'}, type: <type 'dict'>, valid types: <type 'list'>, <type 'tuple'>",), None)
```
If I pass the dictionary as the first item of the list, the error was:
```
Unknown parameter in Tags[0]: "tag_label_GEkvtZ39Xm", must be one of: Key, Value
```