### PR TITLE
[1LP][RFR] Add all_ips method to VM entities

### DIFF
--- a/wrapanapi/entities/vm.py
+++ b/wrapanapi/entities/vm.py
@@ -156,9 +156,17 @@ class Vm(with_metaclass(ABCMeta, Entity)):
     @abstractproperty
     def ip(self):
         """
-        Returns IP address of the VM/instance
+        Returns: (string) externally reachable IP address of the VM/instance (when possible)
 
         Should refresh if necessary to get most up-to-date info
+        """
+
+    @abstractproperty
+    def all_ips(self):
+        """
+        Returns: (list) All ip addresses available on the VM
+
+        For consistency on platforms that return link-local and restricted network addresses
         """
 
     @abstractproperty

--- a/wrapanapi/systems/ec2.py
+++ b/wrapanapi/systems/ec2.py
@@ -102,6 +102,14 @@ class EC2Instance(Instance, _TagMixin):
         return self.raw.public_ip_address
 
     @property
+    def all_ips(self):
+        """ Wrapping self.ip to meet abstractproperty requirement
+
+        Returns: (list) the addresses assigned to the machine
+        """
+        return [self.ip]
+
+    @property
     def type(self):
         return self.raw.instance_type
 

--- a/wrapanapi/systems/google.py
+++ b/wrapanapi/systems/google.py
@@ -101,15 +101,29 @@ class GoogleCloudInstance(Instance):
         return self._api_state_to_vmstate(self.raw['status'])
 
     @property
-    def ip(self):
+    def ip_internal(self):
         self.refresh()
-        return self.raw.get('networkInterfaces')[0].get('networkIP')
+        try:
+            return self.raw.get('networkInterfaces')[0].get('networkIP')
+        except IndexError:
+            return None
 
     @property
-    def ip_external(self):
+    def ip(self):
         self.refresh()
-        access_configs = self.raw.get('networkInterfaces')[0].get('accessConfigs')[0]
-        return access_configs.get('natIP')
+        try:
+            access_configs = self.raw.get('networkInterfaces', [{}])[0].get('accessConfigs', [])[0]
+            return access_configs.get('natIP')
+        except IndexError:
+            return None
+
+    @property
+    def all_ips(self):
+        """ Wrapping self.ip and self.ip_internal to meet abstractproperty requirement
+
+        Returns: (list) the addresses assigned to the machine
+        """
+        return [self.ip, self.ip_internal]
 
     @property
     def type(self):

--- a/wrapanapi/systems/msazure.py
+++ b/wrapanapi/systems/msazure.py
@@ -174,6 +174,18 @@ class AzureInstance(Instance):
         return public_ip.ip_address
 
     @property
+    def all_ips(self):
+        """ Wrapping self.ip to meet abstractproperty requirement
+
+        TODO: Actually fetch the various addresses on non-primary interfaces
+
+        non-public addresses are not necessary for testing at this time, so not implementing
+
+        Returns: (list) the public IPv4 address in a list
+        """
+        return [self.ip]
+
+    @property
     def type(self):
         return self.raw.hardware_profile.vm_size
 

--- a/wrapanapi/systems/openstack.py
+++ b/wrapanapi/systems/openstack.py
@@ -165,6 +165,15 @@ class OpenstackInstance(_SharedMethodsMixin, Instance):
                     return str(nic['addr'])
 
     @property
+    def all_ips(self):
+        """ Get all the IPs on the machine
+
+        Returns: (list) the addresses assigned to the machine
+        """
+        # raw.networks is dict of network: [ip, ip] key:value pairs
+        return [ip for nets in self.raw.networks.values() for ip in nets]
+
+    @property
     def flavor(self):
         if not self._flavor:
             flavor_id = self.raw.flavor['id']

--- a/wrapanapi/systems/rhevm.py
+++ b/wrapanapi/systems/rhevm.py
@@ -61,7 +61,7 @@ class _SharedMethodsMixin(object):
     @property
     def creation_time(self):
         """
-        Returns creation time of VM/instance
+        Returns creation time of VM
         """
         self.refresh()
         return self.raw.creation_time.astimezone(pytz.UTC)
@@ -252,16 +252,22 @@ class RHEVMVirtualMachine(_SharedMethodsMixin, Vm):
     @property
     def ip(self):
         """
-        Returns IPv4 or global IPv6 address of the VM/instance
+        Returns IPv4 or global IPv6 address of the VM
+
+        If there are multiple IP's on the VM, just returns the first non-link-local
         """
-        link_local_prefix = 'fe80::'
+        potentials = []
         for ip in self.all_ips:
-            if link_local_prefix not in ip[:len(link_local_prefix)]:
-                return ip
-        return None
+            if not ip.startswith('fe80::'):
+                potentials.append(ip)
+        return potentials[0] if potentials else None
 
     @property
     def all_ips(self):
+        """ Return all of the IPs
+
+        Returns: (list) the addresses assigned to the machine
+        """
         ips = []
         rep_dev_service = self.api.reported_devices_service()
         for dev in rep_dev_service.list():
@@ -271,7 +277,7 @@ class RHEVMVirtualMachine(_SharedMethodsMixin, Vm):
 
     def start(self):
         """
-        Starts the VM/instance. Blocks until task completes.
+        Starts the VM. Blocks until task completes.
 
         Returns: True if vm action has been initiated properly
         """
@@ -287,7 +293,7 @@ class RHEVMVirtualMachine(_SharedMethodsMixin, Vm):
 
     def stop(self):
         """
-        Stops the VM/instance. Blocks until task completes.
+        Stops the VM. Blocks until task completes.
 
         Returns: True if vm action has been initiated properly
         """
@@ -303,7 +309,7 @@ class RHEVMVirtualMachine(_SharedMethodsMixin, Vm):
 
     def restart(self):
         """
-        Restarts the VM/instance. Blocks until task completes.
+        Restarts the VM. Blocks until task completes.
 
         Returns: True if vm action has been initiated properly
         """
@@ -312,7 +318,7 @@ class RHEVMVirtualMachine(_SharedMethodsMixin, Vm):
 
     def suspend(self):
         """
-        Suspends the VM/instance.  Blocks until task completes.
+        Suspends the VM.  Blocks until task completes.
 
         Returns: True if vm action has been initiated properly
         """

--- a/wrapanapi/systems/scvmm.py
+++ b/wrapanapi/systems/scvmm.py
@@ -145,6 +145,11 @@ class SCVirtualMachine(Vm, _LogStrMixin):
         return ip if ip else None
 
     @property
+    def all_ips(self):
+        """ wrap self.ip to meet abstractproperty """
+        return [self.ip]
+
+    @property
     def creation_time(self):
         self.refresh()
         creation_time = convert_powershell_date(self.raw['CreationTime'])

--- a/wrapanapi/systems/virtualcenter.py
+++ b/wrapanapi/systems/virtualcenter.py
@@ -641,6 +641,13 @@ class VMWareVirtualMachine(VMWareVMOrTemplate, Vm):
             return None
 
     @property
+    def all_ips(self):
+        """vmware is limited, can't get more than one IP for a vm summary
+        wrapper for API consistency
+        """
+        return [self.ip]
+
+    @property
     def creation_time(self):
         """Detect the vm_creation_time either via uptime if non-zero, or by last boot time
 


### PR DESCRIPTION
abstractmethod and implementations for subclasses of VM
OVIRT and vmware in particular are a real pain in the ass when it comes to addresses
With no reasonable way to determine what's a local network IP and what's a public network IP
Provide a property that just returns all the available addresses, allowing the caller to process them

Changed GCE's properties, as `ip` was returning an internal IP, and `ip_external` should have been `ip`