### PR TITLE
[RFR] Add a timezone mapping for windows to pytz and timezone property

### DIFF
--- a/wrapanapi/systems/scvmm.py
+++ b/wrapanapi/systems/scvmm.py
@@ -13,8 +13,8 @@ from textwrap import dedent
 import time
 
 import pytz
-import tzlocal
 import winrm
+from cached_property import cached_property
 from wait_for import wait_for
 
 from wrapanapi.entities import Template, TemplateMixin, Vm, VmMixin, VmState
@@ -22,6 +22,109 @@ from wrapanapi.exceptions import (
     ImageNotFoundError, VMInstanceNotFound, MultipleItemsError
 )
 from wrapanapi.systems.base import System
+
+
+WINDOWS_TZ_INFO = {
+    'AUS Central Standard Time': 'Australia/Darwin',
+    'AUS Eastern Standard Time': 'Australia/Sydney',
+    'Afghanistan Standard Time': 'Asia/Kabul',
+    'Alaskan Standard Time': 'America/Anchorage',
+    'Arab Standard Time': 'Asia/Riyadh',
+    'Arabian Standard Time': 'Asia/Dubai',
+    'Arabic Standard Time': 'Asia/Baghdad',
+    'Argentina Standard Time': 'America/Buenos_Aires',
+    'Atlantic Standard Time': 'America/Halifax',
+    'Azerbaijan Standard Time': 'Asia/Baku',
+    'Azores Standard Time': 'Atlantic/Azores',
+    'Bahia Standard Time': 'America/Bahia',
+    'Bangladesh Standard Time': 'Asia/Dhaka',
+    'Canada Central Standard Time': 'America/Regina',
+    'Cape Verde Standard Time': 'Atlantic/Cape_Verde',
+    'Caucasus Standard Time': 'Asia/Yerevan',
+    'Cen. Australia Standard Time': 'Australia/Adelaide',
+    'Central America Standard Time': 'America/Guatemala',
+    'Central Asia Standard Time': 'Asia/Almaty',
+    'Central Brazilian Standard Time': 'America/Cuiaba',
+    'Central Europe Standard Time': 'Europe/Budapest',
+    'Central European Standard Time': 'Europe/Warsaw',
+    'Central Pacific Standard Time': 'Pacific/Guadalcanal',
+    'Central Standard Time': 'America/Chicago',
+    'Central Standard Time (Mexico)': 'America/Mexico_City',
+    'China Standard Time': 'Asia/Shanghai',
+    'Dateline Standard Time': 'Etc/GMT+12',
+    'E. Africa Standard Time': 'Africa/Nairobi',
+    'E. Australia Standard Time': 'Australia/Brisbane',
+    'E. Europe Standard Time': 'Asia/Nicosia',
+    'E. South America Standard Time': 'America/Sao_Paulo',
+    'Eastern Standard Time': 'America/New_York',
+    'Egypt Standard Time': 'Africa/Cairo',
+    'Ekaterinburg Standard Time': 'Asia/Yekaterinburg',
+    'FLE Standard Time': 'Europe/Kiev',
+    'Fiji Standard Time': 'Pacific/Fiji',
+    'GMT Standard Time': 'Europe/London',
+    'GTB Standard Time': 'Europe/Bucharest',
+    'Georgian Standard Time': 'Asia/Tbilisi',
+    'Greenland Standard Time': 'America/Godthab',
+    'Greenwich Standard Time': 'Atlantic/Reykjavik',
+    'Hawaiian Standard Time': 'Pacific/Honolulu',
+    'India Standard Time': 'Asia/Calcutta',
+    'Iran Standard Time': 'Asia/Tehran',
+    'Israel Standard Time': 'Asia/Jerusalem',
+    'Jordan Standard Time': 'Asia/Amman',
+    'Kaliningrad Standard Time': 'Europe/Kaliningrad',
+    'Korea Standard Time': 'Asia/Seoul',
+    'Magadan Standard Time': 'Asia/Magadan',
+    'Mauritius Standard Time': 'Indian/Mauritius',
+    'Middle East Standard Time': 'Asia/Beirut',
+    'Montevideo Standard Time': 'America/Montevideo',
+    'Morocco Standard Time': 'Africa/Casablanca',
+    'Mountain Standard Time': 'America/Denver',
+    'Mountain Standard Time (Mexico)': 'America/Chihuahua',
+    'Myanmar Standard Time': 'Asia/Rangoon',
+    'N. Central Asia Standard Time': 'Asia/Novosibirsk',
+    'Namibia Standard Time': 'Africa/Windhoek',
+    'Nepal Standard Time': 'Asia/Katmandu',
+    'New Zealand Standard Time': 'Pacific/Auckland',
+    'Newfoundland Standard Time': 'America/St_Johns',
+    'North Asia East Standard Time': 'Asia/Irkutsk',
+    'North Asia Standard Time': 'Asia/Krasnoyarsk',
+    'Pacific SA Standard Time': 'America/Santiago',
+    'Pacific Standard Time': 'America/Los_Angeles',
+    'Pacific Standard Time (Mexico)': 'America/Santa_Isabel',
+    'Pakistan Standard Time': 'Asia/Karachi',
+    'Paraguay Standard Time': 'America/Asuncion',
+    'Romance Standard Time': 'Europe/Paris',
+    'Russian Standard Time': 'Europe/Moscow',
+    'SA Eastern Standard Time': 'America/Cayenne',
+    'SA Pacific Standard Time': 'America/Bogota',
+    'SA Western Standard Time': 'America/La_Paz',
+    'SE Asia Standard Time': 'Asia/Bangkok',
+    'Samoa Standard Time': 'Pacific/Apia',
+    'Singapore Standard Time': 'Asia/Singapore',
+    'South Africa Standard Time': 'Africa/Johannesburg',
+    'Sri Lanka Standard Time': 'Asia/Colombo',
+    'Syria Standard Time': 'Asia/Damascus',
+    'Taipei Standard Time': 'Asia/Taipei',
+    'Tasmania Standard Time': 'Australia/Hobart',
+    'Tokyo Standard Time': 'Asia/Tokyo',
+    'Tonga Standard Time': 'Pacific/Tongatapu',
+    'Turkey Standard Time': 'Europe/Istanbul',
+    'US Eastern Standard Time': 'America/Indianapolis',
+    'US Mountain Standard Time': 'America/Phoenix',
+    'UTC': 'Etc/GMT',
+    'UTC+12': 'Etc/GMT-12',
+    'UTC-02': 'Etc/GMT+2',
+    'UTC-11': 'Etc/GMT+11',
+    'Ulaanbaatar Standard Time': 'Asia/Ulaanbaatar',
+    'Venezuela Standard Time': 'America/Caracas',
+    'Vladivostok Standard Time': 'Asia/Vladivostok',
+    'W. Australia Standard Time': 'Australia/Perth',
+    'W. Central Africa Standard Time': 'Africa/Lagos',
+    'W. Europe Standard Time': 'Europe/Berlin',
+    'West Asia Standard Time': 'Asia/Tashkent',
+    'West Pacific Standard Time': 'Pacific/Port_Moresby',
+    'Yakutsk Standard Time': 'Asia/Yakutsk'
+}
 
 
 def convert_powershell_date(date_obj_string):
@@ -153,7 +256,7 @@ class SCVirtualMachine(Vm, _LogStrMixin):
     def creation_time(self):
         self.refresh()
         creation_time = convert_powershell_date(self.raw['CreationTime'])
-        return creation_time.replace(tzinfo=tzlocal.get_localzone()).astimezone(pytz.UTC)
+        return creation_time.replace(tzinfo=self.system.timezone).astimezone(pytz.UTC)
 
     def _do_vm(self, action, params=""):
         cmd = (
@@ -454,6 +557,18 @@ class SCVMMSystem(System, VmMixin, TemplateMixin):
         $mycreds = New-Object System.Management.Automation.PSCredential ("{}\\{}", $secpasswd)
         $scvmm_server = Get-SCVMMServer -Computername localhost -Credential $mycreds
         """.format(self.password, self.domain, self.user))
+
+    @cached_property
+    def timezone(self):
+        windows_tz = self.run_script(
+            "[System.TimeZoneInfo]::Local | Select-Object -expandproperty Id"
+        ).decode("UTF-8")
+        tz = None
+        try:
+            tz = pytz.timezone(WINDOWS_TZ_INFO[windows_tz])
+        except KeyError:
+            self.logger.warning("Timezone %s not understood", WINDOWS_TZ_INFO[windows_tz])
+        return tz
 
     def run_script(self, script):
         """Wrapper for running powershell scripts. Ensures the ``pre_script`` is loaded."""

--- a/wrapanapi/systems/scvmm.py
+++ b/wrapanapi/systems/scvmm.py
@@ -13,6 +13,7 @@ from textwrap import dedent
 import time
 
 import pytz
+import tzlocal
 import winrm
 from cached_property import cached_property
 from wait_for import wait_for
@@ -256,7 +257,9 @@ class SCVirtualMachine(Vm, _LogStrMixin):
     def creation_time(self):
         self.refresh()
         creation_time = convert_powershell_date(self.raw['CreationTime'])
-        return creation_time.replace(tzinfo=self.system.timezone).astimezone(pytz.UTC)
+        return creation_time.replace(
+            tzinfo=self.system.timezone or tzlocal.get_localzone()
+        ).astimezone(pytz.UTC)
 
     def _do_vm(self, action, params=""):
         cmd = (


### PR DESCRIPTION
Adding a timezone mapping for windows reported timezones, so that they can be parsed by `pytz`. This allows us to use SCVMM's timezone when getting/setting the `creation_date` of a VM. 