### PR TITLE
[RFR] py3 compatibility for ip method

### DIFF
--- a/wrapanapi/systems/scvmm.py
+++ b/wrapanapi/systems/scvmm.py
@@ -245,7 +245,8 @@ class SCVirtualMachine(Vm, _LogStrMixin):
             "Get-SCVirtualMachine -ID \"{}\" -VMMServer $scvmm_server |"
             "Get-SCVirtualNetworkAdapter | Select IPv4Addresses |"
             "ft -HideTableHeaders".format(self._id))
-        ip = data.translate(None, '{}')
+        table = str.maketrans(dict.fromkeys("{}"))
+        ip = data.decode("utf-8").translate(table)
         return ip if ip else None
 
     @property


### PR DESCRIPTION
Was hitting a `TypeError` in this method due to `run_script` returning a bytes string. 

Also updating travis for py3.7 support. 