### PR TITLE
[RFR] Update travis to use different dist for py2 vs py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: python
-python:
-  - '2.7'
-  - '3.6'
+matrix:
+  include:
+  - name: "python 3.7"
+    python: "3.7"
+    dist: xenial  # xenial required for 3.7
+  - name: "python 2.7"
+    python: "2.7"
+    dist: trusty  # trusty required for 2.7
 install:
   - pip install -U pip setuptools
   - pip install -Ur requirements-test.txt --upgrade-strategy eager

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,27 @@ matrix:
   - name: "python 3.7"
     python: "3.7"
     dist: xenial  # xenial required for 3.7
+    addons:
+      apt:
+        packages:
+          - python3-venv
+          - gcc
+          - gnutls-dev
+          - postgresql
+          - libxml2-dev
+          - libxslt1-dev
+          - libzmq3-dev
+          - libcurl4-openssl-dev
+          - g++
+          - openssl
+          - libffi-dev
+          - python3-dev
+          - libtesseract-dev
+          - libpng-dev
+          - libfreetype6-dev
+          - libssl-dev
+          - python3-dbg
+          - git
   - name: "python 2.7"
     python: "2.7"
     dist: trusty  # trusty required for 2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ requests
 six
 tzlocal
 vspk==5.3.2
-wait_for
+wait_for==1.0.14
 websocket_client
 
 # suds jurko supports python3, suds is only used on python2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ boto
 cached_property
 dateparser
 enum34; python_version == '2.7'
-fauxfactory>=2.0.7
+fauxfactory==3.0.2
 google-api-python-client
 google-compute-engine
 inflection


### PR DESCRIPTION
Update for python3 compatibility for travis. 

Version controlling `wait-for` since the latest version has dropped py2 support.
Version controlling `fauxfactory` to v3.0.2 to allow for py2 support. 

