### PR TITLE
[RFR] Try to decode bytes string from run_script

### DIFF
--- a/wrapanapi/systems/scvmm.py
+++ b/wrapanapi/systems/scvmm.py
@@ -246,7 +246,7 @@ class SCVirtualMachine(Vm, _LogStrMixin):
             "Get-SCVirtualNetworkAdapter | Select IPv4Addresses |"
             "ft -HideTableHeaders".format(self._id))
         table = str.maketrans(dict.fromkeys("{}"))
-        ip = data.decode("utf-8").translate(table)
+        ip = data.translate(table)
         return ip if ip else None
 
     @property
@@ -566,7 +566,7 @@ class SCVMMSystem(System, VmMixin, TemplateMixin):
     def timezone(self):
         windows_tz = self.run_script(
             "[System.TimeZoneInfo]::Local | Select-Object -expandproperty Id"
-        ).decode("UTF-8")
+        )
         tz = None
         try:
             tz = pytz.timezone(WINDOWS_TZ_INFO[windows_tz])
@@ -605,7 +605,11 @@ class SCVMMSystem(System, VmMixin, TemplateMixin):
             else:
                 _raise_for_result(result)
 
-        return result.std_out.strip()
+        try:
+            # try to decode bytes string if we can
+            return result.std_out.strip().decode("utf-8")
+        except AttributeError:
+            return result.std_out.strip()
 
     def get_json(self, script, depth=2):
         """

--- a/wrapanapi/systems/scvmm.py
+++ b/wrapanapi/systems/scvmm.py
@@ -397,7 +397,7 @@ class SCVirtualMachine(Vm, _LogStrMixin):
         num_removed_line = [line for line in output if "number_dvds_disconnected:" in line]
         if num_removed_line:
             number_dvds_disconnected = int(
-                num_removed_line[0].split('number_dvds_disconnected:')[1].strip()
+                num_removed_line[0].split('number_dvds_disconnected:')[1].replace(" ", "")
             )
         return number_dvds_disconnected
 


### PR DESCRIPTION
`run_script` returns a bytes string in Python 3, here we try to decode it so that other methods are not broken. 

Also including a fix for `disconnect_dvd_drives` so that the string "+ 1" is parsed correctly. 
```python,
Python 3.7.4 (default, Jul  9 2019, 16:32:37) 
[GCC 9.1.1 20190503 (Red Hat 9.1.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> int("+1")
1
>>> int("+ 1")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: invalid literal for int() with base 10: '+ 1'
>>> 
(.cfme_venv) [jdupuy@localhost wrapanapi]$ python2
Python 2.7.16 (default, Apr 30 2019, 15:54:43) 
[GCC 9.0.1 20190312 (Red Hat 9.0.1-0.10)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> int("+ 1")
1
```