### PR TITLE
[RFR] Use next() instead of calling .next()

### DIFF
--- a/wrapanapi/systems/openstack.py
+++ b/wrapanapi/systems/openstack.py
@@ -1086,8 +1086,8 @@ class OpenstackSystem(System, VmMixin, TemplateMixin):
                     " in any pool", pool_name
                 )
         try:
-            fip = (ip for ip in self.api.floating_ips.list()
-                   if ip.instance_id is None).next()
+            fip = next(ip for ip in self.api.floating_ips.list()
+                   if ip.instance_id is None)
         except StopIteration:
             self.logger.error('No more Floating IPs available')
             return None


### PR DESCRIPTION
this fixes:
```
>           fip = (ip for ip in self.api.floating_ips.list()
                   if ip.instance_id is None).next()
E                  AttributeError: 'generator' object has no attribute 'next'
```