### PR TITLE
[1LP][RFR] Azure iot client, create/add iothub

### DIFF
--- a/wrapanapi/systems/msazure.py
+++ b/wrapanapi/systems/msazure.py
@@ -483,13 +483,12 @@ class AzureSystem(System, VmMixin, TemplateMixin):
         self.client_secret = kwargs.get("password")
         self.tenant = kwargs.get("tenant_id")
         self.subscription_id = kwargs.get("subscription_id")
-        self.resource_group = kwargs.get('resource_group')  # default resource group
-        #self.resource_group = kwargs['provisioning']['resource_group']  # default resource group
-        #self.storage_account = kwargs.get("storage_account")
-        #self.storage_key = kwargs.get("storage_key")
-        #self.template_container = kwargs['provisioning']['template_container']
-        #self.orphaned_discs_path = 'Microsoft.Compute/Images/templates/'
-        #self.region = kwargs["provisioning"]["region_api"].replace(' ', '').lower()
+        self.resource_group = kwargs['provisioning']['resource_group']  # default resource group
+        self.storage_account = kwargs.get("storage_account")
+        self.storage_key = kwargs.get("storage_key")
+        self.template_container = kwargs['provisioning']['template_container']
+        self.orphaned_discs_path = 'Microsoft.Compute/Images/templates/'
+        self.region = kwargs["provisioning"]["region_api"].replace(' ', '').lower()
 
         self.credentials = ServicePrincipalCredentials(client_id=self.client_id,
                                                        secret=self.client_secret,
@@ -560,15 +559,17 @@ class AzureSystem(System, VmMixin, TemplateMixin):
 
     def create_iothub(self, name, sku_name='F1', sku_capacity=1):
         """
-        :param name: iothub name
-        :param sku_name: IotHubSkuInfo.name
-        :param sku_capacity: IotHubSkuInfo.capacity
-        :return:
+        create iothub with specified name
+        sku_name: IotHubSkuInfo.name
+        The name of the SKU. Possible values include: 'F1', 'S1', 'S2', 'S3', 'B1', 'B2', 'B3'
+        Free/Standard/Basic.. defaults to F1
+        sku_capacity: The number of provisioned IoT Hub units.
+
         """
         async_iot_hub = self.iot_client.iot_hub_resource.create_or_update(
             self.resource_group,
             name,
-            {'location': "East US 2",
+            {'location': self.region,
              'subscriptionid': self.subscription_id,
              'resourcegroup': self.resource_group,
              'sku': {

--- a/wrapanapi/systems/msazure.py
+++ b/wrapanapi/systems/msazure.py
@@ -12,6 +12,7 @@ from azure.common import AzureConflictHttpError
 from azure.common.credentials import ServicePrincipalCredentials
 from azure.common.exceptions import CloudError
 from azure.mgmt.compute import ComputeManagementClient
+from azure.mgmt.iothub import IotHubClient
 from azure.mgmt.network import NetworkManagementClient
 from azure.mgmt.network.models import NetworkSecurityGroup, SecurityRule
 from azure.mgmt.resource import ResourceManagementClient, SubscriptionClient
@@ -512,7 +513,7 @@ class AzureSystem(System, VmMixin, TemplateMixin):
     def __setattr__(self, key, value):
         """If the subscription_id is changed, invalidate client caches"""
         if key in ['credentials', 'subscription_id']:
-            for client in ['compute_client', 'resource_client', 'network_client',
+            for client in ['compute_client', 'iot_client', 'resource_client', 'network_client',
                            'subscription_client', 'storage_client']:
                 if getattr(self, client, False):
                     del self.__dict__[client]
@@ -524,6 +525,10 @@ class AzureSystem(System, VmMixin, TemplateMixin):
     @cached_property
     def compute_client(self):
         return ComputeManagementClient(self.credentials, self.subscription_id)
+
+    @cached_property
+    def iot_client(self):
+        return IotHubClient(self.credentials, self.subscription_id)
 
     @cached_property
     def resource_client(self):

--- a/wrapanapi/systems/msazure.py
+++ b/wrapanapi/systems/msazure.py
@@ -559,12 +559,9 @@ class AzureSystem(System, VmMixin, TemplateMixin):
 
     def create_iothub(self, name, sku_name='F1', sku_capacity=1):
         """
-        create iothub with specified name
-        sku_name: IotHubSkuInfo.name
-        The name of the SKU. Possible values include: 'F1', 'S1', 'S2', 'S3', 'B1', 'B2', 'B3'
-        Free/Standard/Basic.. defaults to F1
-        sku_capacity: The number of provisioned IoT Hub units.
-
+        Create an iothub in Azure with the specified name.
+        sku_name and sku_capacity are required for the creation
+        and defaults to 'F1' and '1' for free pricing.
         """
         async_iot_hub = self.iot_client.iot_hub_resource.create_or_update(
             self.resource_group,


### PR DESCRIPTION
Azure iothub wrapper -> add/remove/has_iothub

Required for https://github.com/ManageIQ/integration_tests/pull/9400



Tested locally:

``` python3
from systems.msazure import AzureSystem
azure=AzureSystem(username=username, password=password, tenant_id=tenant,
                  subscription_id=subid,provisioning=provisioning)
azure.create_iothub("potatoiothub")
Out[3]: <azure.mgmt.iothub.models.iot_hub_description_py3.IotHubDescription at 0x7f838d7b8c90>
azure.has_iothub()
Out[4]: True
azure.delete_iothub("potatoiothub")
azure.has_iothub()
Out[6]: False
```

EDIT:
Also works locally in  https://github.com/ManageIQ/integration_tests/pull/9400 with this PR.