### PR TITLE
[RFR]SecurityRule fix, keyword arguments have to be used

### DIFF
--- a/wrapanapi/systems/msazure.py
+++ b/wrapanapi/systems/msazure.py
@@ -850,8 +850,9 @@ class AzureSystem(System, VmMixin, TemplateMixin):
 
         parameters = NetworkSecurityGroup(location=self.region)
         parameters.security_rules = [
-            SecurityRule(protocol, source_address_prefix, destination_address_prefix,
-                access, direction, **kwargs)]
+            SecurityRule(protocol=protocol, source_address_prefix=source_address_prefix,
+                         destination_address_prefix=destination_address_prefix,
+                         access=access, direction=direction, **kwargs)]
         nsg = self.network_client.network_security_groups
         operation = nsg.create_or_update(resource_group, secgroup_name, parameters)
         operation.wait()


### PR DESCRIPTION
Model needs keywords argument instead in newer sdk.