### PR TITLE
[RFR]Adding ability to handle state reboot_in_progress

### DIFF
--- a/wrapanapi/systems/rhevm.py
+++ b/wrapanapi/systems/rhevm.py
@@ -166,6 +166,7 @@ class RHEVMVirtualMachine(_SharedMethodsMixin, Vm):
         'down': VmState.STOPPED,
         'powering_up': VmState.STARTING,
         'suspended': VmState.SUSPENDED,
+        'reboot_in_progress': VmState.STARTING,
     }
 
     def __init__(self, system, raw=None, **kwargs):


### PR DESCRIPTION
When running VM Console tests, Pressing Ctrl+Alt+del causes 'reboot_in_progress' api_state, we need have a map to handle it. 

I was seeing 
```Unmapped VM state 'reboot_in_progress' received from system, mapped to 'VmState.UNKNOWN' ```
and hence this fix. It is apt to map it to state `VmState.STARTING` as that is what ultimately happens when you are Rebooting.