### PR TITLE
[1LP][RFR] fixing collections warning

### DIFF
--- a/wrapanapi/systems/container/rhopenshift.py
+++ b/wrapanapi/systems/container/rhopenshift.py
@@ -2,7 +2,7 @@ import copy
 import json
 import string
 import yaml
-from collections import Iterable
+from collections.abc import Iterable
 from functools import partial, wraps
 from random import choice
 


### PR DESCRIPTION
I thought it had been fixed. unfortunately, it's still present. this PR should get rid of this issue.
```
2019-12-02 08:43:20,805 [W] [py.warnings] ./.cfme_venv/lib64/python3.7/site-packages/wrapanapi/systems/container/rhopenshift.py:5: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
```