### PR TITLE
Typo fix so validate_stats for providers not working

### DIFF
--- a/wrapanapi/systems/base.py
+++ b/wrapanapi/systems/base.py
@@ -70,7 +70,7 @@ class System(LoggerMixin, metaclass=ABCMeta):
                 self.__class__.__name__))
 
         return {stat: self._stats_available[stat](self)
-                for stat in requested_stats or self._status_available.keys()}
+                for stat in requested_stats or self._stats_available.keys()}
 
     def disconnect(self):
         """Disconnects the API from mgmt system"""


### PR DESCRIPTION
There was a typo introduced 4 months ago and def stats in systems/base.py is broken.
