### PR TITLE
[RFR]Deleted instances should be hidden so we can compare with cfme

### DIFF
--- a/wrapanapi/systems/ec2.py
+++ b/wrapanapi/systems/ec2.py
@@ -469,7 +469,7 @@ class EC2System(System, VmMixin, TemplateMixin, StackMixin, NetworkMixin):
     """
 
     _stats_available = {
-        'num_vm': lambda self: len(self.list_vms(hide_deleted=False)),
+        'num_vm': lambda self: len(self.list_vms()),
         'num_template': lambda self: len(self.list_templates()),
     }
 


### PR DESCRIPTION
CFME doesn't count terminated(archived) instances in instance count so we need to do same in wrapanapi.